### PR TITLE
Enhance note styling controls, image cropping, and collapsible cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,7 +305,7 @@
 
     /* ===== Panel de herramientas de imagen ===== */
     .image-toolbar {
-      position: absolute;
+      position: fixed;
       background: #fff;
       border: 2px solid var(--theme-primary);
       border-radius: 6px;
@@ -320,6 +320,32 @@
 
     .image-toolbar.show {
       display: flex;
+    }
+
+    .image-frame {
+      border: 2px solid rgba(13, 110, 253, 0.35);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      background: rgba(13, 110, 253, 0.08);
+      padding: 6px;
+      border-radius: 6px;
+    }
+
+    .image-figure {
+      display: inline-block;
+      margin: 10px;
+      text-align: center;
+      background: #f8f9fa;
+      border: 1px solid #dee2e6;
+      border-radius: 6px;
+      padding: 10px;
+    }
+
+    .image-figure figcaption {
+      margin-top: 8px;
+      font-size: 0.85em;
+      color: #495057;
+      outline: none;
+      min-width: 120px;
     }
 
     .image-toolbar-row {
@@ -367,6 +393,192 @@
       text-align: right;
     }
 
+    /* ===== Plantillas ===== */
+    .template-block {
+      display: block;
+      margin: 8px 0;
+      padding: 4px;
+      border-radius: 6px;
+      transition: box-shadow 0.2s ease, outline 0.2s ease;
+      position: relative;
+    }
+
+    .template-block > :first-child {
+      margin-top: 0;
+    }
+
+    .template-block > :last-child {
+      margin-bottom: 0;
+    }
+
+    .template-block.selected-template {
+      outline: 2px solid var(--theme-primary);
+      outline-offset: 2px;
+      box-shadow: 0 6px 18px rgba(0,0,0,0.15);
+    }
+
+    .template-toolbar {
+      position: fixed;
+      background: #fff;
+      border: 2px solid var(--theme-primary);
+      border-radius: 6px;
+      padding: 10px;
+      display: none;
+      flex-direction: column;
+      gap: 6px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+      z-index: 3500;
+      min-width: 240px;
+    }
+
+    .template-toolbar.show {
+      display: flex;
+    }
+
+    .template-toolbar-row {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .template-toolbar label {
+      font-size: 9px;
+      color: #6c757d;
+      font-weight: 600;
+      min-width: 64px;
+    }
+
+    .template-toolbar input[type="color"] {
+      width: 36px;
+      height: 24px;
+      border: 1px solid #ced4da;
+      border-radius: 4px;
+      padding: 0;
+      background: #fff;
+      cursor: pointer;
+    }
+
+    .template-toolbar input[type="range"] {
+      flex: 1;
+      min-width: 120px;
+    }
+
+    .template-toolbar .size-display {
+      font-size: 9px;
+      color: #495057;
+      min-width: 52px;
+      text-align: right;
+    }
+
+    .template-toolbar button {
+      padding: 4px 8px;
+      border: 1px solid #ced4da;
+      border-radius: 3px;
+      background: #fff;
+      cursor: pointer;
+      font-size: 10px;
+      transition: all 0.15s;
+    }
+
+    .template-toolbar button:hover {
+      background: #f8f9fa;
+    }
+
+    .note-toolbar {
+      position: fixed;
+      background: #fff;
+      border: 2px solid var(--theme-primary);
+      border-radius: 6px;
+      padding: 10px;
+      display: none;
+      flex-direction: column;
+      gap: 6px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+      z-index: 3600;
+      min-width: 240px;
+    }
+
+    .note-toolbar.show {
+      display: flex;
+    }
+
+    .note-toolbar-row {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+
+    .note-toolbar label {
+      font-size: 9px;
+      color: #6c757d;
+      font-weight: 600;
+      min-width: 64px;
+    }
+
+    .note-toolbar .size-display {
+      font-size: 9px;
+      color: #495057;
+      min-width: 52px;
+      text-align: right;
+    }
+
+    .note-toolbar input[type="range"] {
+      flex: 1;
+      min-width: 120px;
+    }
+
+    .note-toolbar button {
+      padding: 4px 8px;
+      border: 1px solid #ced4da;
+      border-radius: 3px;
+      background: #fff;
+      cursor: pointer;
+      font-size: 10px;
+      transition: all 0.15s;
+    }
+
+    .note-toolbar button.danger {
+      color: #dc3545;
+      border-color: rgba(220, 53, 69, 0.4);
+    }
+
+    .note-toolbar button:hover {
+      background: #f8f9fa;
+    }
+
+    .note-palette {
+      display: flex;
+      gap: 4px;
+      flex-wrap: wrap;
+      max-width: 200px;
+    }
+
+    .note-swatch {
+      width: 22px;
+      height: 22px;
+      border-radius: 4px;
+      border: 1px solid #ced4da;
+      cursor: pointer;
+      position: relative;
+      background: transparent;
+      padding: 0;
+    }
+
+    .note-swatch.clear::after {
+      content: '✕';
+      font-size: 11px;
+      color: #dc3545;
+      position: absolute;
+      top: 2px;
+      left: 4px;
+    }
+
+    .note-toolbar-actions {
+      justify-content: space-between;
+      gap: 8px;
+    }
+
     img.selected-image {
       outline: 2px solid var(--theme-primary);
       outline-offset: 2px;
@@ -395,7 +607,30 @@
       margin: 0 5px;
     }
 
-    #loadHtmlInput {
+    .image-figure.float-left {
+      float: left;
+      margin: 0 10px 10px 0;
+    }
+
+    .image-figure.float-right {
+      float: right;
+      margin: 0 0 10px 10px;
+    }
+
+    .image-figure.center-block {
+      display: block;
+      margin: 10px auto;
+      float: none;
+    }
+
+    .image-figure.inline-image {
+      display: inline-block;
+      float: none;
+      margin: 0 5px;
+    }
+
+    #loadHtmlInput,
+    #importDataInput {
       display: none;
     }
 
@@ -411,6 +646,80 @@
       align-items: center;
       justify-content: center;
       z-index: 5000;
+    }
+
+    .crop-modal {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .crop-image-wrapper {
+      position: relative;
+      max-width: 100%;
+      margin: 0 auto;
+      user-select: none;
+    }
+
+    .crop-image-wrapper img {
+      display: block;
+      max-width: 100%;
+      height: auto;
+    }
+
+    .crop-selection {
+      position: absolute;
+      border: 2px dashed var(--theme-primary);
+      background: rgba(13, 110, 253, 0.15);
+      cursor: move;
+      box-sizing: border-box;
+    }
+
+    .crop-handle {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      background: #fff;
+      border: 2px solid var(--theme-primary);
+      position: absolute;
+      cursor: pointer;
+    }
+
+    .crop-handle[data-pos="nw"],
+    .crop-handle[data-pos="ne"],
+    .crop-handle[data-pos="sw"],
+    .crop-handle[data-pos="se"] {
+      transform: translate(-50%, -50%);
+    }
+
+    .crop-handle[data-pos="nw"] { top: 0; left: 0; cursor: nwse-resize; }
+    .crop-handle[data-pos="ne"] { top: 0; right: 0; cursor: nesw-resize; }
+    .crop-handle[data-pos="sw"] { bottom: 0; left: 0; cursor: nesw-resize; }
+    .crop-handle[data-pos="se"] { bottom: 0; right: 0; cursor: nwse-resize; }
+
+    .crop-handle[data-pos="n"],
+    .crop-handle[data-pos="s"] {
+      left: 50%;
+      transform: translate(-50%, -50%);
+      cursor: ns-resize;
+    }
+
+    .crop-handle[data-pos="e"],
+    .crop-handle[data-pos="w"] {
+      top: 50%;
+      transform: translate(-50%, -50%);
+      cursor: ew-resize;
+    }
+
+    .crop-handle[data-pos="n"] { top: 0; }
+    .crop-handle[data-pos="s"] { bottom: 0; }
+    .crop-handle[data-pos="e"] { right: 0; }
+    .crop-handle[data-pos="w"] { left: 0; }
+
+    .crop-controls {
+      display: flex;
+      justify-content: flex-end;
+      gap: 10px;
     }
 
     .modal-overlay.show {
@@ -913,7 +1222,7 @@
       width: 210mm;
       min-height: 297mm;
       padding: 12mm;
-      margin: calc((56px + (20px * var(--zoom-level))) * var(--zoom-level)) auto calc((20px * var(--zoom-level)));
+      margin: calc(76px / var(--zoom-level)) auto calc(20px / var(--zoom-level));
       box-sizing: border-box;
       background: #fff;
       box-shadow: 0 0 15px rgba(0, 0, 0, .1);
@@ -1035,6 +1344,69 @@
       border-radius: 0 4px 4px 0
     }
 
+    .box.selected-note {
+      outline: 2px solid var(--theme-primary-light);
+      outline-offset: 2px;
+    }
+
+    .collapsible-card {
+      border: 1px solid #ced4da;
+      border-radius: 6px;
+      margin: 8px 0;
+      background: #fff;
+      overflow: hidden;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+      transition: box-shadow 0.2s ease;
+    }
+
+    .collapsible-card.collapsed {
+      box-shadow: none;
+    }
+
+    .collapsible-card .collapsible-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      background: var(--theme-primary);
+      color: #fff;
+      padding: 8px 10px;
+    }
+
+    .collapsible-card .collapsible-title {
+      flex: 1;
+      font-weight: 600;
+    }
+
+    .collapsible-toggle {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      border: none;
+      background: rgba(255,255,255,0.2);
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      font-size: 16px;
+      transition: transform 0.2s ease;
+    }
+
+    .collapsible-card.collapsed .collapsible-toggle {
+      transform: rotate(-90deg);
+    }
+
+    .collapsible-card .collapsible-content {
+      padding: 10px 12px;
+      background: #fff;
+      color: #212529;
+      border-top: 1px solid rgba(0,0,0,0.05);
+    }
+
+    .collapsible-card.collapsed .collapsible-content {
+      display: none;
+    }
+
     .pearl {
       border-left-color: #fd7e14
     }
@@ -1119,7 +1491,7 @@
       width: 210mm;
       min-height: 297mm;
       padding: 12mm;
-      margin: calc(20px * var(--zoom-level)) auto;
+      margin: calc(24px / var(--zoom-level)) auto;
       background: #fff;
       box-shadow: 0 0 15px rgba(0, 0, 0, .1);
       box-sizing: border-box;
@@ -1220,6 +1592,14 @@
         min-height: auto;
       }
 
+      .print-hide-temp {
+        display: none !important;
+      }
+
+      .collapsible-card.collapsed .collapsible-content {
+        display: block !important;
+      }
+
       @page {
         size: auto;
         margin: 10mm;
@@ -1247,6 +1627,8 @@
       <button class="topbar-btn" id="loadHtmlBtn" title="Cargar archivo HTML"><span>📂</span> <span class="topbar-btn-label">Abrir</span></button>
       <button class="topbar-btn" id="editBtn" title="Modo edición"><span>✏️</span> <span class="topbar-btn-label">Editar</span></button>
       <button class="topbar-btn" id="saveHtmlBtn" style="display:none;" title="Guardar como HTML"><span>💾</span> <span class="topbar-btn-label">Guardar</span></button>
+      <button class="topbar-btn" id="exportDataBtn" title="Exportar secciones y temas"><span aria-hidden="true">📤</span></button>
+      <button class="topbar-btn" id="importDataBtn" title="Importar secciones y temas"><span aria-hidden="true">📥</span></button>
       <button class="topbar-btn" id="exportMarkdownBtn" title="Exportar a Markdown"><span>⬇️</span> <span class="topbar-btn-label">MD</span></button>
       <button class="topbar-btn" id="copyHtmlBtn" title="Copiar HTML completo"><span>📋</span> <span class="topbar-btn-label">Copiar</span></button>
       <button class="topbar-btn" id="printCurrentBtn" title="Imprimir documento"><span>🖨️</span> <span class="topbar-btn-label">Imprimir</span></button>
@@ -1256,6 +1638,7 @@
   <button class="reading-mode-exit" id="readingModeExit" title="Salir del modo lectura">✕</button>
 
   <input type="file" id="loadHtmlInput" accept=".html" multiple />
+  <input type="file" id="importDataInput" accept="application/json" />
 
   <!-- Barra de herramientas -->
   <div class="edit-toolbar" id="editToolbar">
@@ -1314,6 +1697,7 @@
         <button id="insertOlBtn" title="Numerada">1.</button>
         <button id="insertHtmlBtn" title="HTML personalizado">&lt;/&gt;</button>
         <button id="insertTemplateBtn" title="Plantillas">📝</button>
+        <button id="insertCollapsibleBtn" title="Tarjeta colapsable">🗂️</button>
       </div>
 
       <div class="toolbar-separator"></div>
@@ -1354,17 +1738,90 @@
       <button id="inlineBtn" title="En línea">↔️</button>
     </div>
     <div class="image-toolbar-row">
+      <label for="imageAltInput">Alt:</label>
+      <input type="text" id="imageAltInput" placeholder="Texto alternativo" style="flex:1; font-size: 11px; padding: 4px;">
+      <button id="applyAltBtn" title="Aplicar texto alternativo">Aplicar</button>
+    </div>
+    <div class="image-toolbar-row">
+      <label for="imageFrameToggle">Marco:</label>
+      <input type="checkbox" id="imageFrameToggle" style="margin-right: 6px;">
+      <span style="font-size: 10px; color: #495057;">Agregar marco</span>
+    </div>
+    <div class="image-toolbar-row">
+      <button id="wrapFigureBtn" title="Agregar figura" style="flex:1;">➕ Cuadro</button>
+      <button id="unwrapFigureBtn" title="Quitar figura" style="flex:1;">➖ Quitar</button>
+    </div>
+    <div class="image-toolbar-row">
+      <button id="cropImageBtn" title="Recortar imagen" style="flex:1;">✂️ Recortar</button>
+    </div>
+    <div class="image-toolbar-row">
       <label>Ancho:</label>
-      <input type="range" id="imageWidthSlider" min="50" max="800" step="10">
+      <input type="range" id="imageWidthSlider" min="50" max="900" step="1">
       <span class="size-display" id="widthDisplay">200px</span>
     </div>
     <div class="image-toolbar-row">
       <label>Alto:</label>
-      <input type="range" id="imageHeightSlider" min="50" max="800" step="10">
+      <input type="range" id="imageHeightSlider" min="50" max="900" step="1">
       <span class="size-display" id="heightDisplay">auto</span>
     </div>
     <div class="image-toolbar-row">
       <button id="deleteImageBtn" title="Eliminar" style="color: #dc3545; flex: 1;">🗑️ Eliminar</button>
+    </div>
+  </div>
+
+  <div class="template-toolbar" id="templateToolbar">
+    <div class="template-toolbar-row">
+      <label for="templateBgColor">Fondo:</label>
+      <input type="color" id="templateBgColor" value="#ffffff">
+      <button id="templateClearBgBtn" title="Quitar fondo">Sin fondo</button>
+    </div>
+    <div class="template-toolbar-row">
+      <label for="templateTextColor">Texto:</label>
+      <input type="color" id="templateTextColor" value="#212529">
+      <button id="templateResetTextColorBtn" title="Restablecer color">Restablecer</button>
+    </div>
+    <div class="template-toolbar-row">
+      <label for="templateFontSize">Tamaño:</label>
+      <input type="range" id="templateFontSize" min="80" max="180" step="5">
+      <span class="size-display" id="templateFontSizeDisplay">100%</span>
+    </div>
+    <div class="template-toolbar-row">
+      <label for="templateMarginTop">Arriba:</label>
+      <input type="range" id="templateMarginTop" min="0" max="120" step="1">
+      <span class="size-display" id="templateMarginTopDisplay">0px</span>
+    </div>
+    <div class="template-toolbar-row">
+      <label for="templateMarginBottom">Abajo:</label>
+      <input type="range" id="templateMarginBottom" min="0" max="120" step="1">
+      <span class="size-display" id="templateMarginBottomDisplay">0px</span>
+    </div>
+    <div class="template-toolbar-row">
+      <button id="templateDeleteBtn" title="Eliminar plantilla" style="color:#dc3545; flex:1;">🗑️ Eliminar</button>
+    </div>
+  </div>
+
+  <div class="note-toolbar" id="noteToolbar">
+    <div class="note-toolbar-row">
+      <label for="noteBorderWidth">Borde:</label>
+      <input type="range" id="noteBorderWidth" min="0" max="12" step="1">
+      <span class="size-display" id="noteBorderWidthDisplay">1px</span>
+    </div>
+    <div class="note-toolbar-row">
+      <label for="noteAccentWidth">Izquierdo:</label>
+      <input type="range" id="noteAccentWidth" min="0" max="24" step="1">
+      <span class="size-display" id="noteAccentWidthDisplay">4px</span>
+    </div>
+    <div class="note-toolbar-row">
+      <label>Color borde:</label>
+      <div class="note-palette" id="noteBorderPalette"></div>
+    </div>
+    <div class="note-toolbar-row">
+      <label>Fondo:</label>
+      <div class="note-palette" id="noteBackgroundPalette"></div>
+    </div>
+    <div class="note-toolbar-row note-toolbar-actions">
+      <button id="noteClearBackgroundBtn">Fondo transparente</button>
+      <button id="noteDeleteBtn" class="danger">Eliminar nota</button>
     </div>
   </div>
 
@@ -1432,9 +1889,13 @@
       let pages = [...document.querySelectorAll('.page')];
       let globalTopicCounter = 1;
       let selectedImage = null;
+      let selectedTemplateBlock = null;
+      let selectedNoteBox = null;
       let currentZoom = 1;
       let allSectionsExpanded = true;
       let savedSelection = null;
+      let activeCropCleanup = null;
+      let notePalettesReady = false;
       
       let sections = [
         {
@@ -1463,17 +1924,58 @@
       const loadHtmlInput = document.getElementById('loadHtmlInput');
       const editToolbar = document.getElementById('editToolbar');
       const statsBtn = document.getElementById('statsBtn');
+      const exportDataBtn = document.getElementById('exportDataBtn');
+      const importDataBtn = document.getElementById('importDataBtn');
+      const importDataInput = document.getElementById('importDataInput');
       const editPanelBtn = document.getElementById('editPanelBtn');
       const tocBtn = document.getElementById('tocBtn');
       const readingModeBtn = document.getElementById('readingModeBtn');
       const readingModeExit = document.getElementById('readingModeExit');
       const exportMarkdownBtn = document.getElementById('exportMarkdownBtn');
       const imageToolbar = document.getElementById('imageToolbar');
+      const imageAltInput = document.getElementById('imageAltInput');
+      const applyAltBtn = document.getElementById('applyAltBtn');
+      const imageFrameToggle = document.getElementById('imageFrameToggle');
+      const wrapFigureBtn = document.getElementById('wrapFigureBtn');
+      const unwrapFigureBtn = document.getElementById('unwrapFigureBtn');
+      const templateToolbar = document.getElementById('templateToolbar');
+      const templateBgColorInput = document.getElementById('templateBgColor');
+      const templateClearBgBtn = document.getElementById('templateClearBgBtn');
+      const templateTextColorInput = document.getElementById('templateTextColor');
+      const templateResetTextColorBtn = document.getElementById('templateResetTextColorBtn');
+      const templateFontSizeSlider = document.getElementById('templateFontSize');
+      const templateFontSizeDisplay = document.getElementById('templateFontSizeDisplay');
+      const templateMarginTopSlider = document.getElementById('templateMarginTop');
+      const templateMarginTopDisplay = document.getElementById('templateMarginTopDisplay');
+      const templateMarginBottomSlider = document.getElementById('templateMarginBottom');
+      const templateMarginBottomDisplay = document.getElementById('templateMarginBottomDisplay');
+      const templateDeleteBtn = document.getElementById('templateDeleteBtn');
+      const alignButtons = {
+        left: document.getElementById('alignLeftBtn'),
+        center: document.getElementById('alignCenterBtn'),
+        right: document.getElementById('alignRightBtn'),
+        inline: document.getElementById('inlineBtn')
+      };
+      const floatClasses = ['float-left', 'float-right', 'center-block', 'inline-image'];
       const zoomInBtn = document.getElementById('zoomInBtn');
       const zoomOutBtn = document.getElementById('zoomOutBtn');
       const zoomValue = document.getElementById('zoomValue');
       const highlightPalette = document.getElementById('highlightPalette');
       const textColorPalette = document.getElementById('textColorPalette');
+      const insertTemplateBtn = document.getElementById('insertTemplateBtn');
+      const insertCollapsibleBtn = document.getElementById('insertCollapsibleBtn');
+      const insertHtmlBtn = document.getElementById('insertHtmlBtn');
+      const insertTableBtn = document.getElementById('insertTableBtn');
+      const cropImageBtn = document.getElementById('cropImageBtn');
+      const noteToolbar = document.getElementById('noteToolbar');
+      const noteBorderWidth = document.getElementById('noteBorderWidth');
+      const noteBorderWidthDisplay = document.getElementById('noteBorderWidthDisplay');
+      const noteAccentWidth = document.getElementById('noteAccentWidth');
+      const noteAccentWidthDisplay = document.getElementById('noteAccentWidthDisplay');
+      const noteBorderPalette = document.getElementById('noteBorderPalette');
+      const noteBackgroundPalette = document.getElementById('noteBackgroundPalette');
+      const noteClearBackgroundBtn = document.getElementById('noteClearBackgroundBtn');
+      const noteDeleteBtn = document.getElementById('noteDeleteBtn');
 
       const pastelColors = [
         '#FFB6C1', '#FFD1DC', '#FFC8DD', '#E7C6FF', '#C8B6FF', '#B4D4FF', '#AEC6CF', '#B2DFDB',
@@ -1677,6 +2179,9 @@
       document.addEventListener('keydown', (event) => {
         if (event.key === 'Escape') {
           hideTopicMenu();
+          hideTemplateToolbar();
+          hideImageToolbar();
+          hideNoteToolbar();
         }
       });
 
@@ -1694,7 +2199,7 @@
       function saveCurrentSelection() {
         const selection = window.getSelection();
         if (selection.rangeCount > 0) {
-          savedSelection = selection.getRangeAt(0);
+          savedSelection = selection.getRangeAt(0).cloneRange();
           return true;
         }
         return false;
@@ -1702,12 +2207,421 @@
 
       function restoreSelection() {
         if (savedSelection) {
+          if (!document.contains(savedSelection.startContainer) || !document.contains(savedSelection.endContainer)) {
+            savedSelection = null;
+            return false;
+          }
           const selection = window.getSelection();
           selection.removeAllRanges();
-          selection.addRange(savedSelection);
-          return true;
+          try {
+            selection.addRange(savedSelection);
+            return true;
+          } catch (err) {
+            savedSelection = null;
+          }
         }
         return false;
+      }
+
+      function ensureEditableSelection() {
+        if (restoreSelection()) {
+          const restored = window.getSelection();
+          if (restored.rangeCount > 0) {
+            return restored;
+          }
+        }
+
+        const selection = window.getSelection();
+        if (selection.rangeCount > 0) {
+          return selection;
+        }
+
+        const activeEditable = document.activeElement && document.activeElement.isContentEditable
+          ? document.activeElement
+          : null;
+        const target = activeEditable || getCurrentMagicPage() || getCurrentPage();
+        if (!target) return null;
+
+        const range = document.createRange();
+        range.selectNodeContents(target);
+        range.collapse(false);
+        selection.removeAllRanges();
+        selection.addRange(range);
+        return selection;
+      }
+
+      function insertNodeAtSelection(node) {
+        const selection = ensureEditableSelection();
+        if (!selection || !selection.rangeCount) return null;
+        const range = selection.getRangeAt(0);
+        range.deleteContents();
+        range.insertNode(node);
+        range.setStartAfter(node);
+        range.setEndAfter(node);
+        selection.removeAllRanges();
+        selection.addRange(range);
+        savedSelection = null;
+        return node;
+      }
+
+      function insertHtmlAtSelection(html) {
+        const selection = ensureEditableSelection();
+        if (!selection || !selection.rangeCount) return null;
+        const range = selection.getRangeAt(0);
+        range.deleteContents();
+        const fragment = range.createContextualFragment(html);
+        const nodes = Array.from(fragment.childNodes);
+        range.insertNode(fragment);
+        const lastNode = nodes[nodes.length - 1];
+        if (lastNode) {
+          range.setStartAfter(lastNode);
+          range.setEndAfter(lastNode);
+        }
+        selection.removeAllRanges();
+        selection.addRange(range);
+        savedSelection = null;
+        return nodes[0] || null;
+      }
+
+      function normalizeColorToHex(color, fallback = '#ffffff') {
+        if (!color || color === 'transparent' || color === 'rgba(0, 0, 0, 0)') {
+          return fallback;
+        }
+        if (color.startsWith('#')) {
+          if (color.length === 4) {
+            return '#' + color.slice(1).split('').map(ch => ch + ch).join('');
+          }
+          return color;
+        }
+        const rgbMatch = color.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)/i);
+        if (rgbMatch) {
+          return '#' + rgbMatch.slice(1, 4).map(value => {
+            const hex = parseInt(value, 10).toString(16);
+            return hex.length === 1 ? '0' + hex : hex;
+          }).join('');
+        }
+        const temp = document.createElement('div');
+        temp.style.color = color;
+        document.body.appendChild(temp);
+        const computed = window.getComputedStyle(temp).color;
+        document.body.removeChild(temp);
+        if (computed === color) {
+          return fallback;
+        }
+        return normalizeColorToHex(computed, fallback);
+      }
+
+      function parsePxValue(value, fallback = 0) {
+        if (!value) return fallback;
+        const parsed = parseFloat(value);
+        return Number.isFinite(parsed) ? Math.round(parsed) : fallback;
+      }
+
+      function createTemplateBlock(template) {
+        if (!template) return null;
+        const block = document.createElement('div');
+        block.className = 'template-block';
+        block.dataset.templateBlock = 'true';
+        if (template.name) {
+          block.dataset.templateName = template.name;
+        }
+        block.dataset.fontScale = '100';
+        block.setAttribute('tabindex', '0');
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = template.html;
+        while (wrapper.firstChild) {
+          block.appendChild(wrapper.firstChild);
+        }
+        return block;
+      }
+
+      function updateTemplateToolbarState(block) {
+        if (!block || !templateToolbar) return;
+        const computed = window.getComputedStyle(block);
+
+        if (templateBgColorInput) {
+          const bgValue = block.dataset.bgColor || block.style.backgroundColor || computed.backgroundColor;
+          templateBgColorInput.value = normalizeColorToHex(bgValue, '#ffffff');
+        }
+
+        if (templateTextColorInput) {
+          const textValue = block.dataset.textColor || block.style.color || computed.color;
+          templateTextColorInput.value = normalizeColorToHex(textValue, '#212529');
+        }
+
+        if (templateFontSizeSlider && templateFontSizeDisplay) {
+          const fontScale = parseInt(block.dataset.fontScale || '100', 10) || 100;
+          templateFontSizeSlider.value = fontScale;
+          templateFontSizeDisplay.textContent = fontScale + '%';
+        }
+
+        if (templateMarginTopSlider && templateMarginTopDisplay) {
+          const topMax = parseInt(templateMarginTopSlider.max || '120', 10);
+          let marginTop = block.dataset.marginTop !== undefined
+            ? parseInt(block.dataset.marginTop, 10)
+            : parsePxValue(block.style.marginTop || computed.marginTop, 0);
+          marginTop = Number.isFinite(marginTop) ? Math.max(0, Math.min(topMax, marginTop)) : 0;
+          templateMarginTopSlider.value = marginTop;
+          templateMarginTopDisplay.textContent = marginTop + 'px';
+        }
+
+        if (templateMarginBottomSlider && templateMarginBottomDisplay) {
+          const bottomMax = parseInt(templateMarginBottomSlider.max || '120', 10);
+          let marginBottom = block.dataset.marginBottom !== undefined
+            ? parseInt(block.dataset.marginBottom, 10)
+            : parsePxValue(block.style.marginBottom || computed.marginBottom, 0);
+          marginBottom = Number.isFinite(marginBottom) ? Math.max(0, Math.min(bottomMax, marginBottom)) : 0;
+          templateMarginBottomSlider.value = marginBottom;
+          templateMarginBottomDisplay.textContent = marginBottom + 'px';
+        }
+      }
+
+      function updateTemplateToolbarPosition(block) {
+        if (!templateToolbar || !block) return;
+        templateToolbar.classList.add('show');
+        const rect = block.getBoundingClientRect();
+        const toolbarWidth = templateToolbar.offsetWidth || 260;
+        const toolbarHeight = templateToolbar.offsetHeight || 220;
+
+        let left = rect.right + 12;
+        let top = rect.top;
+
+        if (left + toolbarWidth > window.innerWidth - 10) {
+          left = rect.left - toolbarWidth - 12;
+        }
+
+        if (left < 10) {
+          left = 10;
+        }
+
+        if (top + toolbarHeight > window.innerHeight - 10) {
+          top = window.innerHeight - toolbarHeight - 10;
+        }
+
+        if (top < 10) {
+          top = 10;
+        }
+
+        templateToolbar.style.left = left + 'px';
+        templateToolbar.style.top = top + 'px';
+      }
+
+      function repositionTemplateToolbar() {
+        if (selectedTemplateBlock) {
+          updateTemplateToolbarPosition(selectedTemplateBlock);
+        }
+      }
+
+      function renderNotePalettes() {
+        if (!noteToolbar) return;
+        const themeStyles = getComputedStyle(document.body);
+        const themeColors = ['--theme-primary', '--theme-primary-dark', '--theme-primary-light']
+          .map(token => themeStyles.getPropertyValue(token).trim())
+          .filter(Boolean);
+        const paletteColors = Array.from(new Set([...themeColors, ...pastelColors]));
+
+        if (noteBorderPalette) {
+          noteBorderPalette.innerHTML = '';
+          const defaultBtn = document.createElement('button');
+          defaultBtn.type = 'button';
+          defaultBtn.className = 'note-swatch clear';
+          defaultBtn.title = 'Predeterminado';
+          defaultBtn.addEventListener('click', (event) => {
+            event.preventDefault();
+            if (!selectedNoteBox) return;
+            selectedNoteBox.style.borderLeftColor = '';
+            selectedNoteBox.style.borderColor = '';
+            updateNoteToolbarState(selectedNoteBox);
+          });
+          noteBorderPalette.appendChild(defaultBtn);
+
+          paletteColors.forEach(color => {
+            const swatch = document.createElement('button');
+            swatch.type = 'button';
+            swatch.className = 'note-swatch';
+            swatch.style.background = color;
+            swatch.title = color;
+            swatch.addEventListener('click', (event) => {
+              event.preventDefault();
+              if (!selectedNoteBox) return;
+              selectedNoteBox.style.borderLeftColor = color;
+              updateNoteToolbarState(selectedNoteBox);
+            });
+            noteBorderPalette.appendChild(swatch);
+          });
+        }
+
+        if (noteBackgroundPalette) {
+          noteBackgroundPalette.innerHTML = '';
+          const clearBtn = document.createElement('button');
+          clearBtn.type = 'button';
+          clearBtn.className = 'note-swatch clear';
+          clearBtn.title = 'Sin fondo';
+          clearBtn.addEventListener('click', (event) => {
+            event.preventDefault();
+            if (!selectedNoteBox) return;
+            selectedNoteBox.style.backgroundColor = '';
+            updateNoteToolbarState(selectedNoteBox);
+          });
+          noteBackgroundPalette.appendChild(clearBtn);
+
+          paletteColors.forEach(color => {
+            const swatch = document.createElement('button');
+            swatch.type = 'button';
+            swatch.className = 'note-swatch';
+            swatch.style.background = color;
+            swatch.title = color;
+            swatch.addEventListener('click', (event) => {
+              event.preventDefault();
+              if (!selectedNoteBox) return;
+              selectedNoteBox.style.backgroundColor = color;
+              updateNoteToolbarState(selectedNoteBox);
+            });
+            noteBackgroundPalette.appendChild(swatch);
+          });
+        }
+
+        notePalettesReady = true;
+      }
+
+      function updateNoteToolbarPosition(box) {
+        if (!noteToolbar || !box) return;
+        const rect = box.getBoundingClientRect();
+        const toolbarWidth = noteToolbar.offsetWidth || 260;
+        const toolbarHeight = noteToolbar.offsetHeight || 220;
+        let left = rect.right + 12 + window.scrollX;
+        let top = rect.top + window.scrollY;
+
+        if (left + toolbarWidth > window.scrollX + window.innerWidth - 10) {
+          left = rect.left + window.scrollX - toolbarWidth - 12;
+        }
+
+        if (left < window.scrollX + 10) {
+          left = window.scrollX + 10;
+        }
+
+        if (top + toolbarHeight > window.scrollY + window.innerHeight - 10) {
+          top = window.scrollY + window.innerHeight - toolbarHeight - 10;
+        }
+
+        if (top < window.scrollY + 10) {
+          top = window.scrollY + 10;
+        }
+
+        noteToolbar.style.left = left + 'px';
+        noteToolbar.style.top = top + 'px';
+        noteToolbar.classList.add('show');
+      }
+
+      function updateNoteToolbarState(box) {
+        if (!noteToolbar) return;
+        const styles = window.getComputedStyle(box);
+
+        if (noteBorderWidth && noteBorderWidthDisplay) {
+          const generalWidth = Math.round(parseFloat(styles.borderTopWidth) || 0);
+          const min = parseInt(noteBorderWidth.min || '0', 10);
+          const max = parseInt(noteBorderWidth.max || '12', 10);
+          const clamped = Math.max(min, Math.min(max, generalWidth));
+          noteBorderWidth.value = String(clamped);
+          noteBorderWidthDisplay.textContent = clamped + 'px';
+        }
+
+        if (noteAccentWidth && noteAccentWidthDisplay) {
+          const accentWidth = Math.round(parseFloat(styles.borderLeftWidth) || 0);
+          const min = parseInt(noteAccentWidth.min || '0', 10);
+          const max = parseInt(noteAccentWidth.max || '24', 10);
+          const clamped = Math.max(min, Math.min(max, accentWidth));
+          noteAccentWidth.value = String(clamped);
+          noteAccentWidthDisplay.textContent = clamped + 'px';
+        }
+
+        updateNoteToolbarPosition(box);
+      }
+
+      function showNoteToolbar(box) {
+        if (!noteToolbar || !box) return;
+        hideImageToolbar();
+        hideTemplateToolbar();
+        if (selectedNoteBox && selectedNoteBox !== box) {
+          selectedNoteBox.classList.remove('selected-note');
+        }
+        selectedNoteBox = box;
+        box.classList.add('selected-note');
+        if (!notePalettesReady) {
+          renderNotePalettes();
+        }
+        updateNoteToolbarState(box);
+      }
+
+      function hideNoteToolbar() {
+        if (selectedNoteBox) {
+          selectedNoteBox.classList.remove('selected-note');
+          selectedNoteBox = null;
+        }
+        if (noteToolbar) {
+          noteToolbar.classList.remove('show');
+        }
+      }
+
+      function repositionNoteToolbar() {
+        if (selectedNoteBox) {
+          updateNoteToolbarPosition(selectedNoteBox);
+        }
+      }
+
+      function createCollapsibleCard() {
+        const card = document.createElement('div');
+        card.className = 'collapsible-card';
+        card.dataset.collapsible = 'true';
+
+        const header = document.createElement('div');
+        header.className = 'collapsible-header';
+
+        const toggleBtn = document.createElement('button');
+        toggleBtn.type = 'button';
+        toggleBtn.className = 'collapsible-toggle';
+        toggleBtn.textContent = '▼';
+        toggleBtn.setAttribute('aria-expanded', 'true');
+        toggleBtn.contentEditable = 'false';
+
+        const title = document.createElement('div');
+        title.className = 'collapsible-title';
+        title.contentEditable = 'true';
+        title.textContent = 'Título de la tarjeta';
+
+        const content = document.createElement('div');
+        content.className = 'collapsible-content';
+        content.contentEditable = 'true';
+        content.innerHTML = '<p>Contenido de la tarjeta colapsable.</p>';
+
+        header.appendChild(toggleBtn);
+        header.appendChild(title);
+        card.appendChild(header);
+        card.appendChild(content);
+
+        return card;
+      }
+
+      function showTemplateToolbar(block) {
+        if (!templateToolbar || !block) return;
+        if (selectedTemplateBlock && selectedTemplateBlock !== block) {
+          selectedTemplateBlock.classList.remove('selected-template');
+        }
+        hideImageToolbar();
+        selectedTemplateBlock = block;
+        block.classList.add('selected-template');
+        updateTemplateToolbarState(block);
+        updateTemplateToolbarPosition(block);
+      }
+
+      function hideTemplateToolbar() {
+        if (selectedTemplateBlock) {
+          selectedTemplateBlock.classList.remove('selected-template');
+          selectedTemplateBlock = null;
+        }
+        if (templateToolbar) {
+          templateToolbar.classList.remove('show');
+        }
       }
 
       function sanitizeCitations(el) {
@@ -1759,6 +2673,10 @@
         return html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().split(' ').filter(Boolean).length;
       }
 
+      function clamp(value, min, max) {
+        return Math.min(Math.max(value, min), max);
+      }
+
       function getCurrentPage() {
         const viewportCenter = window.scrollY + window.innerHeight / 2;
         return pages.find(p => {
@@ -1779,8 +2697,56 @@
         editableElements.forEach(el => {
           if (el.dataset.pasteHandlerBound === 'true') return;
           el.addEventListener('paste', (e) => {
+            const clipboardData = e.clipboardData;
+            if (!clipboardData) return;
+
+            const items = Array.from(clipboardData.items || []);
+            const imageItems = items.filter(item => item.type && item.type.startsWith('image/'));
+
+            if (imageItems.length) {
+              e.preventDefault();
+              const currentSelection = window.getSelection();
+              const baseRange = currentSelection && currentSelection.rangeCount
+                ? currentSelection.getRangeAt(0).cloneRange()
+                : null;
+
+              imageItems.forEach(item => {
+                const file = item.getAsFile();
+                if (!file) return;
+
+                const reader = new FileReader();
+                reader.onload = (event) => {
+                  const dataUrl = event.target?.result;
+                  if (!dataUrl) return;
+
+                  const selection = window.getSelection();
+                  const range = baseRange ? baseRange.cloneRange() : selection?.getRangeAt(0)?.cloneRange();
+                  if (!range) return;
+
+                  range.deleteContents();
+
+                  const img = document.createElement('img');
+                  img.src = typeof dataUrl === 'string' ? dataUrl : '';
+                  range.insertNode(img);
+
+                  range.setStartAfter(img);
+                  range.collapse(true);
+                  const sel = window.getSelection();
+                  if (!sel) return;
+                  sel.removeAllRanges();
+                  sel.addRange(range);
+                  if (baseRange) {
+                    baseRange.setStartAfter(img);
+                    baseRange.collapse(true);
+                  }
+                };
+                reader.readAsDataURL(file);
+              });
+              return;
+            }
+
             e.preventDefault();
-            const html = e.clipboardData.getData('text/html') || e.clipboardData.getData('text/plain');
+            const html = clipboardData.getData('text/html') || clipboardData.getData('text/plain');
             document.execCommand('insertHTML', false, html);
           });
           el.dataset.pasteHandlerBound = 'true';
@@ -1790,11 +2756,19 @@
       /* === MODAL === */
       function showModal(content) {
         hideTopicMenu();
+        if (typeof activeCropCleanup === 'function') {
+          activeCropCleanup();
+          activeCropCleanup = null;
+        }
         modalContent.innerHTML = content;
         modalOverlay.classList.add('show');
       }
 
       function hideModal() {
+        if (typeof activeCropCleanup === 'function') {
+          activeCropCleanup();
+          activeCropCleanup = null;
+        }
         modalOverlay.classList.remove('show');
         modalContent.innerHTML = '';
       }
@@ -2051,30 +3025,140 @@
       }
 
       /* === MANEJO DE IMÁGENES === */
-      function showImageToolbar(img) {
-        selectedImage = img;
-        img.classList.add('selected-image');
-        
-        const rect = img.getBoundingClientRect();
-        imageToolbar.style.left = rect.left + 'px';
-        imageToolbar.style.top = (rect.top - imageToolbar.offsetHeight - 10) + 'px';
+      function getImageContainer(img) {
+        if (img.parentElement && img.parentElement.classList.contains('image-figure')) {
+          return img.parentElement;
+        }
+        return img;
+      }
+
+      function setActiveAlignButton(activeClass) {
+        Object.values(alignButtons).forEach(btn => btn?.classList.remove('active'));
+        switch (activeClass) {
+          case 'float-left':
+            alignButtons.left?.classList.add('active');
+            break;
+          case 'center-block':
+            alignButtons.center?.classList.add('active');
+            break;
+          case 'float-right':
+            alignButtons.right?.classList.add('active');
+            break;
+          case 'inline-image':
+            alignButtons.inline?.classList.add('active');
+            break;
+        }
+      }
+
+      function updateToolbarPosition(img) {
+        if (!imageToolbar || !img) return;
+
         imageToolbar.classList.add('show');
-        
+
+        const rect = img.getBoundingClientRect();
+        const toolbarWidth = imageToolbar.offsetWidth || 240;
+        const toolbarHeight = imageToolbar.offsetHeight || 160;
+
+        let left = rect.left;
+        let top = rect.top - toolbarHeight - 10;
+
+        if (top < 10) {
+          top = rect.bottom + 10;
+        }
+
+        if (top + toolbarHeight > window.innerHeight - 10) {
+          top = Math.max(10, window.innerHeight - toolbarHeight - 10);
+        }
+
+        if (left + toolbarWidth > window.innerWidth - 10) {
+          left = window.innerWidth - toolbarWidth - 10;
+        }
+
+        if (left < 10) {
+          left = 10;
+        }
+
+        imageToolbar.style.left = left + 'px';
+        imageToolbar.style.top = top + 'px';
+      }
+
+      function updateToolbarState(img) {
+        if (!img) return;
+
+        if (imageAltInput) {
+          imageAltInput.value = img.getAttribute('alt') || '';
+        }
+
+        if (imageFrameToggle) {
+          imageFrameToggle.checked = img.classList.contains('image-frame');
+        }
+
+        if (wrapFigureBtn && unwrapFigureBtn) {
+          const isWrapped = img.parentElement?.classList.contains('image-figure') || false;
+          wrapFigureBtn.disabled = isWrapped;
+          unwrapFigureBtn.disabled = !isWrapped;
+        }
+
+        const container = getImageContainer(img);
+        const activeFloat = floatClasses.find(cls => container.classList.contains(cls));
+        setActiveAlignButton(activeFloat);
+
         const widthSlider = document.getElementById('imageWidthSlider');
         const heightSlider = document.getElementById('imageHeightSlider');
         const widthDisplay = document.getElementById('widthDisplay');
         const heightDisplay = document.getElementById('heightDisplay');
-        
-        widthSlider.value = img.width || 200;
-        widthDisplay.textContent = (img.width || 200) + 'px';
-        
-        if (img.style.height && img.style.height !== 'auto') {
-          heightSlider.value = parseInt(img.style.height) || 200;
-          heightDisplay.textContent = (parseInt(img.style.height) || 200) + 'px';
-        } else {
-          heightSlider.value = img.height || 200;
-          heightDisplay.textContent = 'auto';
+
+        if (widthSlider && widthDisplay) {
+          const widthValue = parseInt(img.style.width) || img.width || 200;
+          const sliderMax = parseInt(widthSlider.max || '900', 10);
+          const sliderMin = parseInt(widthSlider.min || '50', 10);
+          const clampedWidth = Math.max(sliderMin, Math.min(sliderMax, widthValue));
+          widthSlider.value = clampedWidth;
+          widthDisplay.textContent = widthValue + 'px';
         }
+
+        if (heightSlider && heightDisplay) {
+          if (img.style.height && img.style.height !== 'auto') {
+            const parsedHeight = parseInt(img.style.height) || img.height || 200;
+            const sliderMax = parseInt(heightSlider.max || '900', 10);
+            const sliderMin = parseInt(heightSlider.min || '50', 10);
+            const clampedHeight = Math.max(sliderMin, Math.min(sliderMax, parsedHeight));
+            heightSlider.value = clampedHeight;
+            heightDisplay.textContent = parsedHeight + 'px';
+          } else {
+            const autoHeight = img.height || 200;
+            const sliderMax = parseInt(heightSlider.max || '900', 10);
+            const sliderMin = parseInt(heightSlider.min || '50', 10);
+            const clampedAuto = Math.max(sliderMin, Math.min(sliderMax, autoHeight));
+            heightSlider.value = clampedAuto;
+            heightDisplay.textContent = 'auto';
+          }
+        }
+      }
+
+      function repositionImageToolbar() {
+        if (selectedImage) {
+          updateToolbarPosition(selectedImage);
+        }
+      }
+
+      window.addEventListener('scroll', repositionImageToolbar, { passive: true });
+      window.addEventListener('resize', repositionImageToolbar);
+      window.addEventListener('scroll', repositionTemplateToolbar, { passive: true });
+      window.addEventListener('resize', repositionTemplateToolbar);
+      window.addEventListener('scroll', repositionNoteToolbar, { passive: true });
+      window.addEventListener('resize', repositionNoteToolbar);
+
+      function showImageToolbar(img) {
+        hideTemplateToolbar();
+        if (selectedImage && selectedImage !== img) {
+          selectedImage.classList.remove('selected-image');
+        }
+        selectedImage = img;
+        img.classList.add('selected-image');
+
+        updateToolbarState(img);
+        updateToolbarPosition(img);
       }
 
       function hideImageToolbar() {
@@ -2089,8 +3173,48 @@
         if (isEditMode && e.target.tagName === 'IMG') {
           e.preventDefault();
           showImageToolbar(e.target);
-        } else if (!e.target.closest('#imageToolbar') && !e.target.closest('img')) {
+        } else if (!e.target.closest('#imageToolbar') && !e.target.closest('img') && !e.target.closest('.image-figure')) {
           hideImageToolbar();
+        }
+
+        if (isEditMode) {
+          const noteBox = e.target.closest('.box');
+          let handledNote = false;
+          if (noteBox) {
+            handledNote = true;
+            showNoteToolbar(noteBox);
+          } else if (!e.target.closest('#noteToolbar')) {
+            hideNoteToolbar();
+          }
+
+          if (!handledNote) {
+            const templateBlock = e.target.closest('.template-block');
+            if (templateBlock) {
+              showTemplateToolbar(templateBlock);
+            } else if (!e.target.closest('#templateToolbar')) {
+              hideTemplateToolbar();
+            }
+          } else if (!e.target.closest('#templateToolbar')) {
+            hideTemplateToolbar();
+          }
+        } else {
+          if (!e.target.closest('#noteToolbar')) {
+            hideNoteToolbar();
+          }
+          if (!e.target.closest('#templateToolbar')) {
+            hideTemplateToolbar();
+          }
+        }
+
+        const collapsibleToggle = e.target.closest('.collapsible-toggle');
+        if (collapsibleToggle) {
+          const card = collapsibleToggle.closest('.collapsible-card');
+          if (card) {
+            e.preventDefault();
+            card.classList.toggle('collapsed');
+            const expanded = !card.classList.contains('collapsed');
+            collapsibleToggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+          }
         }
       });
 
@@ -2099,6 +3223,7 @@
           const width = parseInt(e.target.value);
           selectedImage.style.width = width + 'px';
           document.getElementById('widthDisplay').textContent = width + 'px';
+          repositionImageToolbar();
         }
       });
 
@@ -2107,31 +3232,517 @@
           const height = parseInt(e.target.value);
           selectedImage.style.height = height + 'px';
           document.getElementById('heightDisplay').textContent = height + 'px';
+          repositionImageToolbar();
         }
       });
 
-      document.getElementById('alignLeftBtn')?.addEventListener('click', () => {
-        if (selectedImage) {
-          selectedImage.className = 'float-left';
+      templateBgColorInput?.addEventListener('input', (e) => {
+        if (!selectedTemplateBlock) return;
+        const color = e.target.value || '#ffffff';
+        selectedTemplateBlock.dataset.bgColor = color;
+        selectedTemplateBlock.style.backgroundColor = color;
+        repositionTemplateToolbar();
+      });
+
+      templateClearBgBtn?.addEventListener('click', () => {
+        if (!selectedTemplateBlock) return;
+        delete selectedTemplateBlock.dataset.bgColor;
+        selectedTemplateBlock.style.backgroundColor = 'transparent';
+        if (templateBgColorInput) {
+          templateBgColorInput.value = '#ffffff';
+        }
+        repositionTemplateToolbar();
+      });
+
+      templateTextColorInput?.addEventListener('input', (e) => {
+        if (!selectedTemplateBlock) return;
+        const color = e.target.value || '#212529';
+        selectedTemplateBlock.dataset.textColor = color;
+        selectedTemplateBlock.style.color = color;
+      });
+
+      templateResetTextColorBtn?.addEventListener('click', () => {
+        if (!selectedTemplateBlock) return;
+        delete selectedTemplateBlock.dataset.textColor;
+        selectedTemplateBlock.style.color = '';
+        if (templateTextColorInput) {
+          templateTextColorInput.value = '#212529';
         }
       });
 
-      document.getElementById('alignCenterBtn')?.addEventListener('click', () => {
-        if (selectedImage) {
-          selectedImage.className = 'center-block';
+      noteBorderWidth?.addEventListener('input', (e) => {
+        if (!selectedNoteBox) return;
+        const value = clamp(parseInt(e.target.value, 10) || 0,
+          parseInt(noteBorderWidth.min || '0', 10),
+          parseInt(noteBorderWidth.max || '12', 10));
+        selectedNoteBox.style.borderStyle = 'solid';
+        selectedNoteBox.style.borderWidth = value + 'px';
+        if (noteAccentWidth) {
+          const accent = clamp(parseInt(noteAccentWidth.value, 10) || value,
+            parseInt(noteAccentWidth.min || '0', 10),
+            parseInt(noteAccentWidth.max || '24', 10));
+          selectedNoteBox.style.borderLeftWidth = accent + 'px';
+        }
+        if (noteBorderWidthDisplay) {
+          noteBorderWidthDisplay.textContent = value + 'px';
+        }
+        repositionNoteToolbar();
+      });
+
+      noteAccentWidth?.addEventListener('input', (e) => {
+        if (!selectedNoteBox) return;
+        const value = clamp(parseInt(e.target.value, 10) || 0,
+          parseInt(noteAccentWidth.min || '0', 10),
+          parseInt(noteAccentWidth.max || '24', 10));
+        selectedNoteBox.style.borderLeftWidth = value + 'px';
+        if (noteAccentWidthDisplay) {
+          noteAccentWidthDisplay.textContent = value + 'px';
+        }
+        repositionNoteToolbar();
+      });
+
+      noteClearBackgroundBtn?.addEventListener('click', () => {
+        if (!selectedNoteBox) return;
+        selectedNoteBox.style.backgroundColor = '';
+        updateNoteToolbarState(selectedNoteBox);
+      });
+
+      noteDeleteBtn?.addEventListener('click', () => {
+        if (!selectedNoteBox) return;
+        const toRemove = selectedNoteBox;
+        hideNoteToolbar();
+        toRemove.remove();
+      });
+
+      templateFontSizeSlider?.addEventListener('input', (e) => {
+        if (!selectedTemplateBlock) return;
+        const size = parseInt(e.target.value, 10) || 100;
+        selectedTemplateBlock.dataset.fontScale = String(size);
+        selectedTemplateBlock.style.fontSize = size === 100 ? '' : size + '%';
+        if (templateFontSizeDisplay) {
+          templateFontSizeDisplay.textContent = size + '%';
+        }
+        repositionTemplateToolbar();
+      });
+
+      templateMarginTopSlider?.addEventListener('input', (e) => {
+        if (!selectedTemplateBlock) return;
+        const margin = parseInt(e.target.value, 10) || 0;
+        selectedTemplateBlock.dataset.marginTop = String(margin);
+        selectedTemplateBlock.style.marginTop = margin + 'px';
+        if (templateMarginTopDisplay) {
+          templateMarginTopDisplay.textContent = margin + 'px';
+        }
+        repositionTemplateToolbar();
+      });
+
+      templateMarginBottomSlider?.addEventListener('input', (e) => {
+        if (!selectedTemplateBlock) return;
+        const margin = parseInt(e.target.value, 10) || 0;
+        selectedTemplateBlock.dataset.marginBottom = String(margin);
+        selectedTemplateBlock.style.marginBottom = margin + 'px';
+        if (templateMarginBottomDisplay) {
+          templateMarginBottomDisplay.textContent = margin + 'px';
+        }
+        repositionTemplateToolbar();
+      });
+
+      templateDeleteBtn?.addEventListener('click', () => {
+        if (!selectedTemplateBlock) return;
+        const block = selectedTemplateBlock;
+        const range = document.createRange();
+        range.setStartAfter(block);
+        range.collapse(true);
+        block.remove();
+        const selection = window.getSelection();
+        selection.removeAllRanges();
+        selection.addRange(range);
+        savedSelection = null;
+        hideTemplateToolbar();
+      });
+
+      function applyFloatClass(targetClass) {
+        if (!selectedImage) return;
+
+        const container = getImageContainer(selectedImage);
+
+        floatClasses.forEach(cls => {
+          container.classList.remove(cls);
+          if (container !== selectedImage) {
+            selectedImage.classList.remove(cls);
+          }
+        });
+
+        if (targetClass) {
+          container.classList.add(targetClass);
+        }
+
+        setActiveAlignButton(targetClass || '');
+        repositionImageToolbar();
+      }
+
+      alignButtons.left?.addEventListener('click', () => {
+        applyFloatClass('float-left');
+      });
+
+      alignButtons.center?.addEventListener('click', () => {
+        applyFloatClass('center-block');
+      });
+
+      alignButtons.right?.addEventListener('click', () => {
+        applyFloatClass('float-right');
+      });
+
+      alignButtons.inline?.addEventListener('click', () => {
+        applyFloatClass('inline-image');
+      });
+
+      applyAltBtn?.addEventListener('click', () => {
+        if (!selectedImage || !imageAltInput) return;
+        selectedImage.alt = imageAltInput.value.trim();
+        selectedImage.setAttribute('alt', selectedImage.alt);
+        imageAltInput.blur();
+      });
+
+      imageAltInput?.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          applyAltBtn?.click();
         }
       });
 
-      document.getElementById('alignRightBtn')?.addEventListener('click', () => {
-        if (selectedImage) {
-          selectedImage.className = 'float-right';
+      imageFrameToggle?.addEventListener('change', (e) => {
+        if (!selectedImage) return;
+        if (e.target.checked) {
+          selectedImage.classList.add('image-frame');
+        } else {
+          selectedImage.classList.remove('image-frame');
         }
+        repositionImageToolbar();
       });
 
-      document.getElementById('inlineBtn')?.addEventListener('click', () => {
-        if (selectedImage) {
-          selectedImage.className = 'inline-image';
+      function wrapImageWithFigure() {
+        if (!selectedImage || selectedImage.parentElement?.classList.contains('image-figure')) return;
+
+        const container = getImageContainer(selectedImage);
+        const existingFloat = floatClasses.find(cls => container.classList.contains(cls));
+
+        const figure = document.createElement('figure');
+        figure.classList.add('image-figure');
+
+        if (existingFloat) {
+          container.classList.remove(existingFloat);
+          figure.classList.add(existingFloat);
         }
+
+        const caption = document.createElement('figcaption');
+        caption.contentEditable = 'true';
+        caption.spellcheck = true;
+        caption.textContent = 'Escribe una descripción';
+
+        const parent = selectedImage.parentElement;
+        parent?.insertBefore(figure, selectedImage);
+        figure.appendChild(selectedImage);
+        figure.appendChild(caption);
+
+        caption.focus();
+
+        if (wrapFigureBtn) wrapFigureBtn.disabled = true;
+        if (unwrapFigureBtn) unwrapFigureBtn.disabled = false;
+
+        updateToolbarState(selectedImage);
+        updateToolbarPosition(selectedImage);
+      }
+
+      function unwrapImageFigure() {
+        if (!selectedImage) return;
+        const figure = selectedImage.parentElement;
+        if (!figure || !figure.classList.contains('image-figure')) return;
+
+        const existingFloat = floatClasses.find(cls => figure.classList.contains(cls));
+        const parent = figure.parentElement;
+        if (!parent) return;
+
+        parent.insertBefore(selectedImage, figure);
+        figure.remove();
+
+        if (existingFloat) {
+          selectedImage.classList.add(existingFloat);
+        }
+
+        if (wrapFigureBtn) wrapFigureBtn.disabled = false;
+        if (unwrapFigureBtn) unwrapFigureBtn.disabled = true;
+
+        updateToolbarState(selectedImage);
+        updateToolbarPosition(selectedImage);
+      }
+
+      function openCropModal(image) {
+        if (!image) return;
+        const naturalWidth = image.naturalWidth || image.width || 1;
+        const naturalHeight = image.naturalHeight || image.height || 1;
+        const handles = ['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w']
+          .map(pos => `<span class="crop-handle" data-pos="${pos}"></span>`)
+          .join('');
+
+        showModal(`
+          <div class="modal-header">
+            <h3>Recortar imagen</h3>
+            <button class="modal-close" id="cropModalClose" title="Cerrar">&times;</button>
+          </div>
+          <div class="modal-body">
+            <div class="crop-modal">
+              <div class="crop-image-wrapper" id="cropImageWrapper">
+                <img id="cropPreviewImage" src="${image.src}" alt="Previsualización de recorte">
+                <div class="crop-selection" id="cropSelection">${handles}</div>
+              </div>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <div class="crop-controls">
+              <button class="modal-btn" type="button" id="cropCancelBtn">Cancelar</button>
+              <button class="modal-btn primary" type="button" id="cropApplyBtn">Aplicar</button>
+            </div>
+          </div>
+        `);
+
+        const preview = document.getElementById('cropPreviewImage');
+        const selection = document.getElementById('cropSelection');
+        const wrapper = document.getElementById('cropImageWrapper');
+        const applyBtn = document.getElementById('cropApplyBtn');
+        const cancelBtn = document.getElementById('cropCancelBtn');
+        const closeBtn = document.getElementById('cropModalClose');
+
+        if (!preview || !selection || !wrapper || !applyBtn) {
+          return;
+        }
+
+        const state = {
+          pointerId: null,
+          mode: null,
+          handle: null,
+          startX: 0,
+          startY: 0,
+          startRect: { x: 0, y: 0, width: 0, height: 0 },
+          selection: { x: 0, y: 0, width: 0, height: 0 },
+          anchor: null
+        };
+
+        const cleanupCallbacks = [];
+        const registerCleanup = (fn) => cleanupCallbacks.push(fn);
+
+        function updateSelectionStyles() {
+          const { x, y, width, height } = state.selection;
+          selection.style.left = `${x}px`;
+          selection.style.top = `${y}px`;
+          selection.style.width = `${width}px`;
+          selection.style.height = `${height}px`;
+        }
+
+        function setSelection(x, y, width, height) {
+          const boundsWidth = wrapper.clientWidth || naturalWidth;
+          const boundsHeight = wrapper.clientHeight || naturalHeight;
+          const minSize = 20;
+          const safeWidth = clamp(width, minSize, boundsWidth);
+          const safeHeight = clamp(height, minSize, boundsHeight);
+          const safeX = clamp(x, 0, boundsWidth - safeWidth);
+          const safeY = clamp(y, 0, boundsHeight - safeHeight);
+          state.selection = { x: safeX, y: safeY, width: safeWidth, height: safeHeight };
+          updateSelectionStyles();
+        }
+
+        function resetInteraction() {
+          state.pointerId = null;
+          state.mode = null;
+          state.handle = null;
+          state.anchor = null;
+        }
+
+        function startInteraction(mode, pointerId, clientX, clientY, handle = null) {
+          state.pointerId = pointerId;
+          state.mode = mode;
+          state.handle = handle;
+          state.startX = clientX;
+          state.startY = clientY;
+          state.startRect = { ...state.selection };
+        }
+
+        function getRelativeCoords(clientX, clientY) {
+          const rect = wrapper.getBoundingClientRect();
+          return {
+            x: clamp(clientX - rect.left, 0, rect.width || naturalWidth),
+            y: clamp(clientY - rect.top, 0, rect.height || naturalHeight)
+          };
+        }
+
+        function onPointerMove(event) {
+          if (state.pointerId !== event.pointerId || !state.mode) return;
+          const boundsWidth = wrapper.clientWidth || naturalWidth;
+          const boundsHeight = wrapper.clientHeight || naturalHeight;
+          const dx = event.clientX - state.startX;
+          const dy = event.clientY - state.startY;
+
+          if (state.mode === 'move') {
+            const newX = clamp(state.startRect.x + dx, 0, boundsWidth - state.startRect.width);
+            const newY = clamp(state.startRect.y + dy, 0, boundsHeight - state.startRect.height);
+            setSelection(newX, newY, state.startRect.width, state.startRect.height);
+            return;
+          }
+
+          if (state.mode === 'resize' && state.handle) {
+            let { x, y, width, height } = state.startRect;
+            const minSize = 20;
+
+            if (state.handle.includes('e')) {
+              width = clamp(state.startRect.width + dx, minSize, boundsWidth - x);
+            }
+            if (state.handle.includes('s')) {
+              height = clamp(state.startRect.height + dy, minSize, boundsHeight - y);
+            }
+            if (state.handle.includes('w')) {
+              const newX = clamp(state.startRect.x + dx, 0, state.startRect.x + state.startRect.width - minSize);
+              width = clamp(state.startRect.width + (state.startRect.x - newX), minSize, boundsWidth - newX);
+              x = newX;
+            }
+            if (state.handle.includes('n')) {
+              const newY = clamp(state.startRect.y + dy, 0, state.startRect.y + state.startRect.height - minSize);
+              height = clamp(state.startRect.height + (state.startRect.y - newY), minSize, boundsHeight - newY);
+              y = newY;
+            }
+
+            setSelection(x, y, width, height);
+            return;
+          }
+
+          if (state.mode === 'new' && state.anchor) {
+            const current = getRelativeCoords(event.clientX, event.clientY);
+            const x = Math.min(state.anchor.x, current.x);
+            const y = Math.min(state.anchor.y, current.y);
+            const width = Math.abs(current.x - state.anchor.x);
+            const height = Math.abs(current.y - state.anchor.y);
+            setSelection(x, y, width, height);
+          }
+        }
+
+        function onPointerUp(event) {
+          if (state.pointerId !== event.pointerId) return;
+          resetInteraction();
+        }
+
+        function selectionPointerDown(event) {
+          if (state.pointerId !== null) return;
+          if (event.target.closest('.crop-handle')) return;
+          event.preventDefault();
+          startInteraction('move', event.pointerId, event.clientX, event.clientY);
+        }
+
+        function handlePointerDown(event) {
+          if (state.pointerId !== null) return;
+          event.preventDefault();
+          const handle = event.target.dataset.pos;
+          startInteraction('resize', event.pointerId, event.clientX, event.clientY, handle);
+        }
+
+        function wrapperPointerDown(event) {
+          if (state.pointerId !== null) return;
+          if (event.target === selection || event.target.closest('#cropSelection')) return;
+          event.preventDefault();
+          const anchor = getRelativeCoords(event.clientX, event.clientY);
+          state.anchor = anchor;
+          state.selection = { x: anchor.x, y: anchor.y, width: 20, height: 20 };
+          updateSelectionStyles();
+          startInteraction('new', event.pointerId, event.clientX, event.clientY);
+        }
+
+        function initializeSelection() {
+          const width = wrapper.clientWidth || naturalWidth;
+          const height = wrapper.clientHeight || naturalHeight;
+          setSelection(0, 0, width, height);
+        }
+
+        const handlesNodes = selection.querySelectorAll('.crop-handle');
+        handlesNodes.forEach(handle => handle.addEventListener('pointerdown', handlePointerDown));
+        registerCleanup(() => handlesNodes.forEach(handle => handle.removeEventListener('pointerdown', handlePointerDown)));
+
+        selection.addEventListener('pointerdown', selectionPointerDown);
+        registerCleanup(() => selection.removeEventListener('pointerdown', selectionPointerDown));
+
+        wrapper.addEventListener('pointerdown', wrapperPointerDown);
+        registerCleanup(() => wrapper.removeEventListener('pointerdown', wrapperPointerDown));
+
+        window.addEventListener('pointermove', onPointerMove);
+        window.addEventListener('pointerup', onPointerUp);
+        registerCleanup(() => {
+          window.removeEventListener('pointermove', onPointerMove);
+          window.removeEventListener('pointerup', onPointerUp);
+        });
+
+        const init = () => initializeSelection();
+        if (preview.complete) {
+          init();
+        } else {
+          preview.addEventListener('load', init);
+          registerCleanup(() => preview.removeEventListener('load', init));
+        }
+
+        cancelBtn?.addEventListener('click', (event) => {
+          event.preventDefault();
+          hideModal();
+        });
+
+        closeBtn?.addEventListener('click', (event) => {
+          event.preventDefault();
+          hideModal();
+        });
+
+        applyBtn.addEventListener('click', (event) => {
+          event.preventDefault();
+          const { x, y, width, height } = state.selection;
+          const boundsWidth = wrapper.clientWidth || naturalWidth;
+          const boundsHeight = wrapper.clientHeight || naturalHeight;
+          const scaleX = naturalWidth / boundsWidth;
+          const scaleY = naturalHeight / boundsHeight;
+          const cropX = Math.round(x * scaleX);
+          const cropY = Math.round(y * scaleY);
+          const cropWidth = Math.max(1, Math.round(width * scaleX));
+          const cropHeight = Math.max(1, Math.round(height * scaleY));
+
+          const canvas = document.createElement('canvas');
+          canvas.width = cropWidth;
+          canvas.height = cropHeight;
+          const ctx = canvas.getContext('2d');
+
+          try {
+            ctx.drawImage(image, cropX, cropY, cropWidth, cropHeight, 0, 0, cropWidth, cropHeight);
+            const dataUrl = canvas.toDataURL('image/png');
+            image.src = dataUrl;
+            hideModal();
+            updateToolbarState(image);
+            updateToolbarPosition(image);
+            repositionImageToolbar();
+          } catch (error) {
+            console.error('No se pudo recortar la imagen:', error);
+            alert('No se pudo recortar la imagen (¿es un recurso remoto sin permisos CORS?).');
+          }
+        });
+
+        activeCropCleanup = () => {
+          cleanupCallbacks.forEach(fn => {
+            try { fn(); } catch (e) {}
+          });
+          cleanupCallbacks.length = 0;
+          resetInteraction();
+        };
+      }
+
+      wrapFigureBtn?.addEventListener('click', wrapImageWithFigure);
+      unwrapFigureBtn?.addEventListener('click', unwrapImageFigure);
+      cropImageBtn?.addEventListener('click', () => {
+        if (!selectedImage) {
+          alert('Selecciona una imagen para recortar.');
+          return;
+        }
+        openCropModal(selectedImage);
       });
 
       document.getElementById('deleteImageBtn')?.addEventListener('click', () => {
@@ -2283,23 +3894,64 @@
 
       document.addEventListener('click', (e) => {
         if (!e.target.closest('#highlightBtn') && !e.target.closest('#highlightPalette')) {
+          const wasOpen = highlightPalette.classList.contains('show');
           highlightPalette.classList.remove('show');
-          if (highlightPalette.classList.contains('show') === false) {
+          if (wasOpen) {
             savedSelection = null;
           }
         }
         if (!e.target.closest('#textColorBtn') && !e.target.closest('#textColorPalette')) {
+          const wasOpen = textColorPalette.classList.contains('show');
           textColorPalette.classList.remove('show');
-          if (textColorPalette.classList.contains('show') === false) {
+          if (wasOpen) {
             savedSelection = null;
           }
         }
       });
 
       /* === PLANTILLAS === */
+      insertTemplateBtn?.addEventListener('pointerdown', () => {
+        saveCurrentSelection();
+      });
+
+      insertTemplateBtn?.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          saveCurrentSelection();
+        }
+      });
+
+      insertHtmlBtn?.addEventListener('pointerdown', () => {
+        saveCurrentSelection();
+      });
+
+      insertHtmlBtn?.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          saveCurrentSelection();
+        }
+      });
+
+      insertTableBtn?.addEventListener('pointerdown', () => {
+        saveCurrentSelection();
+      });
+
+      insertTableBtn?.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          saveCurrentSelection();
+        }
+      });
+
+      insertCollapsibleBtn?.addEventListener('pointerdown', () => {
+        saveCurrentSelection();
+      });
+
+      insertCollapsibleBtn?.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          saveCurrentSelection();
+        }
+      });
+
       document.getElementById('insertTemplateBtn')?.addEventListener('click', () => {
-        const hasSelection = saveCurrentSelection();
-        if (!hasSelection) {
+        if (!savedSelection) {
           const activeEditable = document.activeElement && document.activeElement.isContentEditable ? document.activeElement : null;
           const target = activeEditable || getCurrentPage() || getCurrentMagicPage();
           if (target) {
@@ -2390,30 +4042,36 @@
             <div class="template-preview">${template.html}</div>
           `;
           card.addEventListener('click', () => {
-            let inserted = false;
-            if (restoreSelection()) {
-              execCmd('insertHTML', template.html);
-              inserted = true;
-            } else {
-              const fallback = (document.activeElement && document.activeElement.isContentEditable)
-                ? document.activeElement
-                : (getCurrentPage() || getCurrentMagicPage());
-              if (fallback) {
-                fallback.focus();
-                execCmd('insertHTML', template.html);
-                inserted = true;
-              }
-            }
-
-            if (!inserted) {
+            const block = createTemplateBlock(template);
+            if (!block) return;
+            const insertedBlock = insertNodeAtSelection(block);
+            if (!insertedBlock) {
               alert('Selecciona un área editable antes de insertar una plantilla.');
+              return;
             }
 
-            savedSelection = null;
+            showTemplateToolbar(insertedBlock);
+            insertedBlock.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
             hideModal();
           });
           grid?.appendChild(card);
         });
+      });
+
+      insertCollapsibleBtn?.addEventListener('click', () => {
+        const card = createCollapsibleCard();
+        const inserted = insertNodeAtSelection(card);
+        if (inserted) {
+          const title = inserted.querySelector('.collapsible-title');
+          if (title) {
+            const range = document.createRange();
+            range.selectNodeContents(title);
+            range.collapse(false);
+            const selection = window.getSelection();
+            selection.removeAllRanges();
+            selection.addRange(range);
+          }
+        }
       });
 
       /* === PANEL LATERAL === */
@@ -2472,6 +4130,14 @@
 
         if (isEditMode) {
           magicPage.contentEditable = 'true';
+          wrapper.contentEditable = 'true';
+          const syncMagic = () => {
+            if (src) {
+              src.innerHTML = wrapper.innerHTML;
+            }
+          };
+          wrapper.addEventListener('input', syncMagic);
+          wrapper.addEventListener('blur', syncMagic, true);
           enableHtmlPaste();
         }
 
@@ -2673,7 +4339,26 @@
       }
 
       function printSection(section) {
+        if (!section) {
+          window.print();
+          return;
+        }
+
+        const pagesToShow = new Set(section.temas.map(tema => tema.page));
+        const hiddenPages = [];
+
+        pages.forEach(page => {
+          if (!pagesToShow.has(page)) {
+            page.classList.add('print-hide-temp');
+            hiddenPages.push(page);
+          }
+        });
+
         window.print();
+
+        setTimeout(() => {
+          hiddenPages.forEach(page => page.classList.remove('print-hide-temp'));
+        }, 100);
       }
 
       function printCurrentTopic() {
@@ -2721,6 +4406,8 @@
           closeTocPanel();
           hideModal();
           hideImageToolbar();
+          hideTemplateToolbar();
+          hideNoteToolbar();
           closeMagicView();
           highlightPalette.classList.remove('show');
           textColorPalette.classList.remove('show');
@@ -2738,6 +4425,11 @@
         if (isReadingMode) {
           document.body.classList.add('reading-mode');
         }
+        notePalettesReady = false;
+        if (selectedNoteBox) {
+          renderNotePalettes();
+          updateNoteToolbarState(selectedNoteBox);
+        }
       });
 
       /* === EDICIÓN === */
@@ -2754,6 +4446,7 @@
           editBtn.textContent = '✏️';
           saveHtmlBtn.style.display = 'inline-block';
           enableHtmlPaste();
+          notePalettesReady = false;
         } else {
           pages.forEach(page => page.contentEditable = 'false');
           const magicPages = document.querySelectorAll('.magic-page');
@@ -2762,7 +4455,9 @@
           editBtn.classList.remove('active');
           editBtn.textContent = '✏️';
           saveHtmlBtn.style.display = 'none';
+          hideTemplateToolbar();
           hideImageToolbar();
+          hideNoteToolbar();
         }
       }
       
@@ -2812,8 +4507,12 @@
           document.getElementById('insertCustomHtmlBtn')?.addEventListener('click', () => {
             const htmlCode = document.getElementById('customHtmlInput').value;
             if (htmlCode.trim()) {
-              execCmd('insertHTML', htmlCode);
-              hideModal();
+              const insertedNode = insertHtmlAtSelection(htmlCode);
+              if (insertedNode) {
+                hideModal();
+              } else {
+                alert('Selecciona un área editable antes de insertar HTML.');
+              }
             } else {
               alert('Por favor ingresa código HTML válido');
             }
@@ -2895,9 +4594,13 @@
           tableHTML += '</tr>';
         }
         tableHTML += '</tbody></table></div>';
-        
-        execCmd('insertHTML', tableHTML);
-        hideModal();
+
+        const insertedNode = insertHtmlAtSelection(tableHTML);
+        if (insertedNode) {
+          hideModal();
+        } else {
+          alert('Selecciona un área editable antes de insertar una tabla.');
+        }
       });
     }, 100);
   });
@@ -3068,7 +4771,7 @@ ${document.querySelector('style').textContent}
   
   document.addEventListener('keydown', (e) => {
     if (!isEditMode) return;
-    
+
     if (e.ctrlKey || e.metaKey) {
       switch(e.key.toLowerCase()) {
         case 'b':
@@ -3099,7 +4802,255 @@ ${document.querySelector('style').textContent}
       }
     }
   });
-  
+
+  /* === IMPORTAR / EXPORTAR SECCIONES === */
+  function generateUniqueId(prefix) {
+    return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  function collectDocumentData() {
+    const magicContainer = document.querySelector('.magic-content-container');
+    const sectionMap = new Map();
+    const seenPages = new Set();
+    const exportedSections = [];
+
+    sections.forEach(section => {
+      const baseSectionId = section.id || section.temas.find(t => t.page)?.page?.dataset.sectionId || generateUniqueId('seccion');
+      const baseSectionName = section.nombre || section.temas.find(t => t.page)?.page?.dataset.sectionName || 'Sección';
+      const exportSection = {
+        id: baseSectionId,
+        nombre: baseSectionName,
+        collapsed: !!section.collapsed,
+        temas: []
+      };
+
+      sectionMap.set(baseSectionId, exportSection);
+      exportedSections.push(exportSection);
+
+      section.temas.forEach(tema => {
+        const page = tema.page || pages.find(p => p.dataset.topicId === tema.id);
+        if (!page) return;
+
+        seenPages.add(page);
+        page.dataset.sectionId = baseSectionId;
+        if (!page.dataset.sectionName) {
+          page.dataset.sectionName = baseSectionName;
+        }
+
+        let topicId = page.dataset.topicId || tema.id;
+        if (!topicId) {
+          topicId = generateUniqueId('topic');
+          page.dataset.topicId = topicId;
+        }
+
+        const titleText = (tema.titulo || getTopicTitle(page) || '').trim() || `Tema ${exportSection.temas.length + 1}`;
+        const magicId = magicAnchorFor(page);
+        const magicEl = magicId ? document.getElementById(magicId) : null;
+
+        exportSection.temas.push({
+          id: topicId,
+          titulo: titleText,
+          html: page.innerHTML,
+          sectionId: page.dataset.sectionId,
+          sectionName: page.dataset.sectionName,
+          magicId: magicId || null,
+          magicHtml: magicEl ? magicEl.innerHTML : null
+        });
+      });
+    });
+
+    pages.forEach(page => {
+      if (seenPages.has(page)) return;
+
+      const sectionId = page.dataset.sectionId || generateUniqueId('seccion');
+      const sectionName = page.dataset.sectionName || 'Sección';
+      let exportSection = sectionMap.get(sectionId);
+      if (!exportSection) {
+        exportSection = {
+          id: sectionId,
+          nombre: sectionName,
+          collapsed: false,
+          temas: []
+        };
+        sectionMap.set(sectionId, exportSection);
+        exportedSections.push(exportSection);
+      }
+
+      let topicId = page.dataset.topicId;
+      if (!topicId) {
+        topicId = generateUniqueId('topic');
+        page.dataset.topicId = topicId;
+      }
+
+      const magicId = magicAnchorFor(page);
+      const magicEl = magicId ? document.getElementById(magicId) : null;
+
+      exportSection.temas.push({
+        id: topicId,
+        titulo: getTopicTitle(page) || `Tema ${exportSection.temas.length + 1}`,
+        html: page.innerHTML,
+        sectionId: sectionId,
+        sectionName: sectionName,
+        magicId: magicId || null,
+        magicHtml: magicEl ? magicEl.innerHTML : null
+      });
+    });
+
+    return {
+      specialty: specialtySpan?.textContent || '',
+      sections: exportedSections,
+      magicContainerHtml: magicContainer ? magicContainer.innerHTML : ''
+    };
+  }
+
+  function downloadJsonFile(data, filename) {
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  function importSectionsData(data) {
+    if (!data || !Array.isArray(data.sections)) {
+      throw new Error('El archivo no contiene secciones válidas.');
+    }
+
+    const mainContainer = document.body;
+    const scriptTag = document.querySelector('script');
+    if (!scriptTag) {
+      throw new Error('No se encontró el contenedor principal.');
+    }
+
+    io.disconnect();
+    pages.forEach(page => page.remove());
+
+    if (specialtySpan && typeof data.specialty === 'string') {
+      specialtySpan.textContent = data.specialty;
+    }
+
+    const magicContainer = document.querySelector('.magic-content-container');
+    if (magicContainer && typeof data.magicContainerHtml === 'string') {
+      magicContainer.innerHTML = data.magicContainerHtml;
+      magicContainer.querySelectorAll('.magic-topic').forEach(topic => afterContentSanitize(topic));
+    }
+
+    const newPages = [];
+    const newSections = [];
+
+    data.sections.forEach(sectionData => {
+      const sectionId = sectionData?.id ? String(sectionData.id) : generateUniqueId('seccion');
+      const sectionName = sectionData?.nombre ? String(sectionData.nombre) : 'Sección';
+      const sectionCollapsed = !!sectionData?.collapsed;
+      const sectionInfo = { id: sectionId, nombre: sectionName, collapsed: sectionCollapsed, temas: [] };
+      const topics = Array.isArray(sectionData?.temas) ? sectionData.temas : [];
+
+      topics.forEach(topicData => {
+        const topicId = topicData?.id ? String(topicData.id) : generateUniqueId('topic');
+        const topicSectionName = topicData?.sectionName ? String(topicData.sectionName) : sectionName;
+        const page = document.createElement('section');
+        page.className = 'page';
+        page.dataset.sectionId = sectionId;
+        page.dataset.sectionName = topicSectionName;
+        page.dataset.topicId = topicId;
+        page.innerHTML = typeof topicData?.html === 'string' ? topicData.html : '';
+        mainContainer.insertBefore(page, scriptTag);
+        afterContentSanitize(page);
+        page.contentEditable = isEditMode ? 'true' : 'false';
+
+        const title = (topicData?.titulo && String(topicData.titulo).trim()) || getTopicTitle(page) || `Tema ${sectionInfo.temas.length + 1}`;
+        sectionInfo.temas.push({ id: topicId, titulo: title, page });
+        newPages.push(page);
+
+        if (magicContainer && topicData?.magicId) {
+          const magicId = String(topicData.magicId);
+          let magicTopic = document.getElementById(magicId);
+          if (!magicTopic) {
+            magicTopic = document.createElement('div');
+            magicTopic.id = magicId;
+            magicTopic.className = 'magic-topic';
+            magicContainer.appendChild(magicTopic);
+          }
+          if (typeof topicData.magicHtml === 'string') {
+            magicTopic.innerHTML = topicData.magicHtml;
+            afterContentSanitize(magicTopic);
+          }
+        }
+      });
+
+      newSections.push(sectionInfo);
+    });
+
+    pages = newPages;
+    sections = newSections;
+    allSectionsExpanded = sections.every(section => !section.collapsed);
+    globalTopicCounter = 1;
+
+    pages.forEach(page => io.observe(page));
+    setupMagicIcons();
+    buildSectionsPanel();
+    buildTableOfContents();
+    if (isEditMode) {
+      enableHtmlPaste();
+    }
+    hideImageToolbar();
+    hideTemplateToolbar();
+    savedSelection = null;
+    window.scrollTo({ top: 0 });
+  }
+
+  exportDataBtn?.addEventListener('click', () => {
+    try {
+      const data = collectDocumentData();
+      const specialtySlug = (data.specialty || 'documento').toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9\-]/g, '');
+      const timestamp = new Date().toISOString().replace(/[:T]/g, '-').split('.')[0];
+      const filename = `${specialtySlug || 'documento'}-secciones-${timestamp}.json`;
+      downloadJsonFile(data, filename);
+      const btn = exportDataBtn;
+      if (btn) {
+        const oldHtml = btn.innerHTML;
+        btn.innerHTML = '<span aria-hidden="true">✅</span>';
+        setTimeout(() => {
+          btn.innerHTML = oldHtml;
+        }, 2000);
+      }
+    } catch (error) {
+      console.error('Error al exportar datos:', error);
+      alert('No se pudo exportar el contenido: ' + error.message);
+    }
+  });
+
+  importDataBtn?.addEventListener('click', () => {
+    importDataInput?.click();
+  });
+
+  importDataInput?.addEventListener('change', async (event) => {
+    const file = event.target.files && event.target.files[0];
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      const data = JSON.parse(text);
+      importSectionsData(data);
+      if (importDataBtn) {
+        const oldHtml = importDataBtn.innerHTML;
+        importDataBtn.innerHTML = '<span aria-hidden="true">✅</span>';
+        setTimeout(() => {
+          importDataBtn.innerHTML = oldHtml;
+        }, 2000);
+      }
+    } catch (error) {
+      console.error('Error al importar datos:', error);
+      alert('Error al importar datos: ' + error.message);
+    } finally {
+      event.target.value = '';
+    }
+  });
+
   /* === GUARDAR HTML === */
   saveHtmlBtn?.addEventListener('click', () => {
     const wasEditing = isEditMode;


### PR DESCRIPTION
## Summary
- add a floating note toolbar with sliders and color palettes to restyle note borders and backgrounds
- integrate an image cropping modal alongside existing image tools and keep figure/float options intact
- introduce collapsible cards, per-section printing, refined zoom spacing, and editable magic pages while polishing import/export buttons

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e59c4bf9dc832c99f971b45d974c21