### PR TITLE
Enhance magic notes and theme controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,13 @@
       max-width: 60vw;
       white-space: nowrap;
       overflow: hidden;
-      text-overflow: ellipsis
+      text-overflow: ellipsis;
+      min-height: 1.33rem;
+      line-height: 1.33rem;
+    }
+
+    .topbar-topic:empty::after {
+      content: '';
     }
 
     .topbar-btn {
@@ -458,6 +464,14 @@
       min-width: 64px;
     }
 
+    .template-toolbar select {
+      font-size: 0.952rem;
+      padding: 4px 6px;
+      border-radius: 4px;
+      border: 1px solid #ced4da;
+      background: #fff;
+    }
+
     .template-toolbar input[type="color"] {
       width: 3.43rem;
       height: 2.29rem;
@@ -492,6 +506,11 @@
 
     .template-toolbar button:hover {
       background: #f8f9fa;
+    }
+
+    .template-toolbar .template-style-select[disabled] {
+      opacity: 0.6;
+      cursor: not-allowed;
     }
 
     .template-toolbar .template-color-palette {
@@ -532,6 +551,27 @@
 
     .template-toolbar .template-toolbar-row.compact {
       align-items: flex-start;
+    }
+
+    .template-toolbar .template-toolbar-row.actions {
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .template-toolbar .template-toolbar-row.actions button {
+      flex: 1 1 48%;
+      min-width: 120px;
+    }
+
+    .template-spacer {
+      margin: 6px 0;
+      line-height: 1.2;
+    }
+
+    .template-block .box {
+      resize: both;
+      overflow: auto;
+      min-height: 2.4rem;
     }
 
     img.selected-image {
@@ -1767,48 +1807,106 @@
     }
 
     .table-theme-default {
-      background: linear-gradient(135deg, #fff, #f1f3f5);
+      background: linear-gradient(135deg, #fff, #f8f9fa);
       color: #212529;
     }
 
     .table-theme-ocean {
-      background: linear-gradient(135deg, #0d6efd, #6ea8fe);
-      color: #fff;
+      background: linear-gradient(135deg, #e7f1ff, #d0e2ff);
+      color: #0d47a1;
     }
 
     .table-theme-forest {
-      background: linear-gradient(135deg, #198754, #75b798);
-      color: #fff;
+      background: linear-gradient(135deg, #eaf7f0, #d6f0e0);
+      color: #1b5e20;
     }
 
     .table-theme-sunset {
-      background: linear-gradient(135deg, #fd7e14, #fda861);
-      color: #fff;
+      background: linear-gradient(135deg, #fff4e6, #ffe6cc);
+      color: #ad4e00;
     }
 
     .table-theme-violet {
-      background: linear-gradient(135deg, #6f42c1, #9d7cd4);
-      color: #fff;
+      background: linear-gradient(135deg, #f3edff, #e3dafc);
+      color: #4a148c;
+    }
+
+    .table-theme-sky {
+      background: linear-gradient(135deg, #ecf7ff, #d4ebff);
+      color: #0b5ed7;
+    }
+
+    .table-theme-mint {
+      background: linear-gradient(135deg, #e9fbf3, #d4f5e5);
+      color: #0f766e;
+    }
+
+    .table-theme-sand {
+      background: linear-gradient(135deg, #fff9ec, #fbeed4);
+      color: #8d5524;
+    }
+
+    .table-theme-rose {
+      background: linear-gradient(135deg, #fff0f4, #ffe0eb);
+      color: #ad1d56;
+    }
+
+    .table-theme-slate {
+      background: linear-gradient(135deg, #f3f4f6, #e5e7eb);
+      color: #374151;
+    }
+
+    table[class*="table-theme-"] {
+      background-color: #fff;
     }
 
     table.table-theme-ocean thead th {
-      background: rgba(13, 110, 253, 0.15);
+      background: rgba(13, 110, 253, 0.12);
       color: #0b5ed7;
     }
 
     table.table-theme-forest thead th {
-      background: rgba(25, 135, 84, 0.15);
+      background: rgba(25, 135, 84, 0.12);
       color: #157347;
     }
 
     table.table-theme-sunset thead th {
-      background: rgba(253, 126, 20, 0.18);
-      color: #dc6502;
+      background: rgba(253, 126, 20, 0.14);
+      color: #c05600;
     }
 
     table.table-theme-violet thead th {
-      background: rgba(111, 66, 193, 0.15);
+      background: rgba(111, 66, 193, 0.12);
       color: #59359a;
+    }
+
+    table.table-theme-sky thead th {
+      background: rgba(13, 110, 253, 0.1);
+      color: #0b5ed7;
+    }
+
+    table.table-theme-mint thead th {
+      background: rgba(32, 201, 151, 0.12);
+      color: #0f766e;
+    }
+
+    table.table-theme-sand thead th {
+      background: rgba(253, 171, 55, 0.14);
+      color: #8d5524;
+    }
+
+    table.table-theme-rose thead th {
+      background: rgba(214, 51, 132, 0.12);
+      color: #a61e4d;
+    }
+
+    table.table-theme-slate thead th {
+      background: rgba(73, 80, 87, 0.12);
+      color: #343a40;
+    }
+
+    table[class*="table-theme-"] tbody td {
+      background: #fff;
     }
 
     .table-resize-handle {
@@ -2023,7 +2121,7 @@
       <button class="topbar-btn topbar-plus" title="Abrir panel de navegación"><span>☰</span> <span class="topbar-btn-label">Menú</span></button>
     </div>
     <div class="topbar-center">
-      <span id="specialtyTitle" class="topbar-topic" title="Especialidad">Endocrinología</span>
+      <span id="specialtyTitle" class="topbar-topic" title="Especialidad"></span>
       <div class="zoom-controls">
         <button class="topbar-btn" id="zoomOutBtn" title="Reducir zoom">-</button>
         <span class="zoom-value" id="zoomValue">100%</span>
@@ -2125,10 +2223,18 @@
       <div class="toolbar-group">
         <span class="toolbar-label">TEMA</span>
         <select id="themeSelect" title="Esquema">
-          <option value="theme-blue">Azul</option>
-          <option value="theme-green">Verde</option>
+          <option value="">Automático</option>
+          <option value="theme-blue">Azul clásico</option>
+          <option value="theme-indigo">Índigo</option>
+          <option value="theme-teal">Verde agua</option>
+          <option value="theme-green">Verde bosque</option>
+          <option value="theme-lime">Verde lima</option>
+          <option value="theme-amber">Ámbar</option>
+          <option value="theme-orange">Mandarina</option>
+          <option value="theme-rose">Rosa</option>
           <option value="theme-purple">Morado</option>
-          <option value="theme-orange">Naranja</option>
+          <option value="theme-violet">Lavanda</option>
+          <option value="theme-slate">Gris azulado</option>
         </select>
         <button id="duplicateTopicBtn" title="Duplicar">📑</button>
         <button id="exportTopicBtn" title="Exportar">💾</button>
@@ -2232,6 +2338,21 @@
             </button>
             <button type="button" class="table-theme-option" data-table-theme="table-theme-violet">
               <span class="table-theme-sample table-theme-violet">Violeta</span>
+            </button>
+            <button type="button" class="table-theme-option" data-table-theme="table-theme-sky">
+              <span class="table-theme-sample table-theme-sky">Cielo</span>
+            </button>
+            <button type="button" class="table-theme-option" data-table-theme="table-theme-mint">
+              <span class="table-theme-sample table-theme-mint">Menta</span>
+            </button>
+            <button type="button" class="table-theme-option" data-table-theme="table-theme-sand">
+              <span class="table-theme-sample table-theme-sand">Arena</span>
+            </button>
+            <button type="button" class="table-theme-option" data-table-theme="table-theme-rose">
+              <span class="table-theme-sample table-theme-rose">Rosa</span>
+            </button>
+            <button type="button" class="table-theme-option" data-table-theme="table-theme-slate">
+              <span class="table-theme-sample table-theme-slate">Gris</span>
             </button>
           </div>
         </div>
@@ -2337,6 +2458,23 @@
       <div class="template-color-palette" id="templateAccentPalette"></div>
       <input type="color" id="templateAccentColor" value="#0d6efd">
     </div>
+    <div class="template-toolbar-row" id="templateStyleRow">
+      <label for="templateStyleSelect">Estilo:</label>
+      <select id="templateStyleSelect" class="template-style-select">
+        <option value="">Personalizado</option>
+        <option value="note-classic">Clásica</option>
+        <option value="note-soft-blue">Azul suave</option>
+        <option value="note-soft-green">Verde suave</option>
+        <option value="note-soft-amber">Ámbar suave</option>
+        <option value="note-soft-rose">Rosa suave</option>
+        <option value="note-soft-violet">Lavanda</option>
+        <option value="note-soft-slate">Gris suave</option>
+      </select>
+    </div>
+    <div class="template-toolbar-row actions" id="templateSpacingRow">
+      <button id="templateSpaceBeforeBtn" type="button">Espacio arriba</button>
+      <button id="templateSpaceAfterBtn" type="button">Espacio abajo</button>
+    </div>
     <div class="template-toolbar-row">
       <label for="templateFontSize">Tamaño:</label>
       <input type="range" id="templateFontSize" min="80" max="180" step="5">
@@ -2412,6 +2550,7 @@
       let allSectionsExpanded = true;
       let savedSelection = null;
       let tableMenuAPI = null;
+      let activePage = null;
       const cropState = {
         image: null,
         isSelecting: false,
@@ -2481,6 +2620,11 @@
       const templateAccentColorInput = document.getElementById('templateAccentColor');
       const templateBorderColorRow = document.getElementById('templateBorderColorRow');
       const templateAccentColorRow = document.getElementById('templateAccentColorRow');
+      const templateStyleSelect = document.getElementById('templateStyleSelect');
+      const templateStyleRow = document.getElementById('templateStyleRow');
+      const templateSpacingRow = document.getElementById('templateSpacingRow');
+      const templateSpaceBeforeBtn = document.getElementById('templateSpaceBeforeBtn');
+      const templateSpaceAfterBtn = document.getElementById('templateSpaceAfterBtn');
       const templateFontSizeSlider = document.getElementById('templateFontSize');
       const templateFontSizeDisplay = document.getElementById('templateFontSizeDisplay');
       const templateMarginTopSlider = document.getElementById('templateMarginTop');
@@ -2490,11 +2634,40 @@
       const templateBorderWidthSlider = document.getElementById('templateBorderWidth');
       const templateBorderWidthDisplay = document.getElementById('templateBorderWidthDisplay');
       const templateDeleteBtn = document.getElementById('templateDeleteBtn');
+      const themeSelect = document.getElementById('themeSelect');
 
       const templateBackgroundPaletteColors = ['#ffffff', '#f8f9fa', '#fef9e7', '#fff3cd', '#fde2e4', '#f8d7da', '#e7f3ff', '#d1e7dd', '#e9ecef'];
       const templateTextPaletteColors = ['#212529', '#343a40', '#0d6efd', '#198754', '#dc3545', '#fd7e14', '#6f42c1', '#6c757d', '#ffffff'];
       const templateBorderPaletteColors = ['#ced4da', '#adb5bd', '#0d6efd', '#198754', '#dc3545', '#fd7e14', '#6f42c1', '#0dcaf0', '#6c757d', '#212529'];
       const templateAccentPaletteColors = ['#0d6efd', '#198754', '#dc3545', '#fd7e14', '#6f42c1', '#ffc107', '#20c997', '#0dcaf0', '#6c757d'];
+
+      const noteStylePresets = [
+        { id: 'note-classic', label: 'Clásica', background: '#ffffff', text: '#212529', border: '#ced4da', accent: '#0d6efd', accentExtra: 2 },
+        { id: 'note-soft-blue', label: 'Azul suave', background: '#f1f6ff', text: '#0b4f79', border: '#9ec5fe', accent: '#0d6efd', accentExtra: 3 },
+        { id: 'note-soft-green', label: 'Verde suave', background: '#eef7f1', text: '#1f5130', border: '#9cd2ae', accent: '#198754', accentExtra: 3 },
+        { id: 'note-soft-amber', label: 'Ámbar suave', background: '#fff7e6', text: '#7c4a03', border: '#ffd8a8', accent: '#fd7e14', accentExtra: 3 },
+        { id: 'note-soft-rose', label: 'Rosa suave', background: '#fff0f4', text: '#7b2146', border: '#f5b8cf', accent: '#d63384', accentExtra: 3 },
+        { id: 'note-soft-violet', label: 'Lavanda', background: '#f4f1ff', text: '#4c2d7a', border: '#cdb4f8', accent: '#6f42c1', accentExtra: 3 },
+        { id: 'note-soft-slate', label: 'Gris suave', background: '#f7f8fa', text: '#343a40', border: '#ced4da', accent: '#6c757d', accentExtra: 2 }
+      ];
+
+      const themeDefinitions = {
+        'theme-blue': { primary: '#0d6efd', dark: '#0b5ed7', light: '#6ea8fe' },
+        'theme-indigo': { primary: '#6610f2', dark: '#520dc2', light: '#b197fc' },
+        'theme-teal': { primary: '#20c997', dark: '#0f766e', light: '#63e6be' },
+        'theme-green': { primary: '#198754', dark: '#157347', light: '#75b798' },
+        'theme-lime': { primary: '#66bb6a', dark: '#2e7d32', light: '#a5d6a7' },
+        'theme-amber': { primary: '#ffa94d', dark: '#d9480f', light: '#ffd8a8' },
+        'theme-orange': { primary: '#fd7e14', dark: '#dc6502', light: '#fda861' },
+        'theme-rose': { primary: '#d63384', dark: '#b42d70', light: '#f3a6cc' },
+        'theme-purple': { primary: '#6f42c1', dark: '#59359a', light: '#9d7cd4' },
+        'theme-violet': { primary: '#845ef7', dark: '#5f3dc4', light: '#bca8ff' },
+        'theme-slate': { primary: '#495057', dark: '#343a40', light: '#adb5bd' }
+      };
+
+      const MAGIC_BASE_WIDTH = 793.8;
+      const MAGIC_BASE_MIN_HEIGHT = 1122.45;
+      const MAGIC_BASE_PADDING = 45.36;
 
       initPalette(templateBgPalette, templateBackgroundPaletteColors, color => applyTemplateBackground(color));
       initPalette(templateTextPalette, templateTextPaletteColors, color => applyTemplateTextColor(color));
@@ -2633,6 +2806,9 @@
         buildSectionsPanel();
         buildTableOfContents();
         setupMagicIcons();
+        if (page === activePage) {
+          updateTopbarContext(page);
+        }
         return true;
       }
 
@@ -2680,6 +2856,10 @@
         initializeSections();
         buildSectionsPanel();
         buildTableOfContents();
+        activePage = getCurrentPage();
+        updateActiveThemeContext(activePage);
+        updateTopbarContext(activePage);
+        syncThemeSelectWithPage(activePage);
         return true;
       }
 
@@ -2693,6 +2873,8 @@
         }
         const newId = 'topic-' + Date.now() + '-' + Math.random().toString(36).substr(2, 6);
         clone.dataset.topicId = newId;
+        clone.dataset.theme = page.dataset.theme || '';
+        setPageTheme(clone, clone.dataset.theme || '');
         clone.contentEditable = isEditMode ? 'true' : 'false';
         page.parentNode.insertBefore(clone, page.nextSibling);
         pages = [...document.querySelectorAll('.page')];
@@ -2701,6 +2883,10 @@
         initializeSections();
         buildSectionsPanel();
         buildTableOfContents();
+        activePage = clone;
+        updateActiveThemeContext(clone);
+        updateTopbarContext(clone);
+        syncThemeSelectWithPage(clone);
         clone.scrollIntoView({ behavior: 'smooth', block: 'start' });
         return clone;
       }
@@ -2759,6 +2945,7 @@
         currentZoom = Math.max(0.5, Math.min(2, level));
         document.documentElement.style.setProperty('--zoom-level', currentZoom);
         zoomValue.textContent = Math.round(currentZoom * 100) + '%';
+        updateMagicZoom();
       }
 
       function updateZoom(delta) {
@@ -2906,6 +3093,9 @@
         while (wrapper.firstChild) {
           block.appendChild(wrapper.firstChild);
         }
+        if (template.noteStyle) {
+          applyNoteStylePreset(block, template.noteStyle, { skipToolbarUpdate: true });
+        }
         return block;
       }
 
@@ -2981,10 +3171,155 @@
         });
       }
 
+      function getThemeDefinition(themeName) {
+        return themeDefinitions[themeName] || themeDefinitions['theme-blue'];
+      }
+
+      function applyThemeVariables(target, themeName) {
+        if (!target) return;
+        const theme = getThemeDefinition(themeName);
+        target.style.setProperty('--theme-primary', theme.primary);
+        target.style.setProperty('--theme-primary-dark', theme.dark);
+        target.style.setProperty('--theme-primary-light', theme.light);
+      }
+
+      function clearThemeVariables(target) {
+        if (!target) return;
+        target.style.removeProperty('--theme-primary');
+        target.style.removeProperty('--theme-primary-dark');
+        target.style.removeProperty('--theme-primary-light');
+      }
+
+      function setPageTheme(page, themeName) {
+        if (!page) return;
+        if (themeName && themeDefinitions[themeName]) {
+          applyThemeVariables(page, themeName);
+          page.dataset.theme = themeName;
+        } else {
+          clearThemeVariables(page);
+          delete page.dataset.theme;
+        }
+      }
+
+      function getPageTheme(page) {
+        return page?.dataset?.theme || '';
+      }
+
+      function updateActiveThemeContext(page) {
+        const themeName = getPageTheme(page) || 'theme-blue';
+        applyThemeVariables(document.documentElement, themeName);
+      }
+
+      function syncThemeSelectWithPage(page) {
+        if (!themeSelect) return;
+        const themeValue = getPageTheme(page) || '';
+        const options = Array.from(themeSelect.options || []);
+        if (options.some(option => option.value === themeValue)) {
+          themeSelect.value = themeValue;
+        } else {
+          themeSelect.value = '';
+        }
+      }
+
+      function updateTopbarContext(page) {
+        if (!specialtySpan) return;
+        const topicTitle = page ? (getTopicTitle(page) || '').trim() : '';
+        specialtySpan.textContent = topicTitle;
+        specialtySpan.title = topicTitle || specialtySpan.dataset.specialty || '';
+      }
+
+      function applyThemeToMagicPage(magicPage, themeName) {
+        if (!magicPage) return;
+        if (themeName && themeDefinitions[themeName]) {
+          applyThemeVariables(magicPage, themeName);
+        } else {
+          clearThemeVariables(magicPage);
+        }
+      }
+
+      function updateMagicZoom() {
+        const scale = currentZoom > 0 ? 1 / currentZoom : 1;
+        const magicPages = document.querySelectorAll('.magic-page');
+        magicPages.forEach(page => {
+          page.style.transformOrigin = 'top center';
+          page.style.transform = `scale(${scale})`;
+          page.style.width = (MAGIC_BASE_WIDTH * currentZoom) + 'px';
+          page.style.minHeight = (MAGIC_BASE_MIN_HEIGHT * currentZoom) + 'px';
+          page.style.padding = (MAGIC_BASE_PADDING * currentZoom) + 'px';
+        });
+      }
+
+      function insertTemplateSpacer(position) {
+        if (!selectedTemplateBlock) return;
+        const parent = selectedTemplateBlock.parentElement;
+        if (!parent) return;
+        const target = getTemplateTarget(selectedTemplateBlock);
+        if (!target || !target.classList.contains('box')) return;
+        const spacer = document.createElement('p');
+        spacer.className = 'template-spacer';
+        spacer.innerHTML = '<br>';
+        if (position === 'before') {
+          parent.insertBefore(spacer, selectedTemplateBlock);
+        } else {
+          parent.insertBefore(spacer, selectedTemplateBlock.nextSibling);
+        }
+        spacer.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
+
+      function markNoteStyleAsCustom(block) {
+        if (!block || !block.dataset) return;
+        if (block.dataset.noteStyle) {
+          delete block.dataset.noteStyle;
+          if (block === selectedTemplateBlock && templateStyleSelect) {
+            templateStyleSelect.value = '';
+          }
+        }
+      }
+
+      function applyNoteStylePreset(block, styleId, options = {}) {
+        if (!block) return;
+        const target = getTemplateTarget(block);
+        if (!target || !target.classList.contains('box')) return;
+        if (!styleId) {
+          markNoteStyleAsCustom(block);
+          if (!options.skipToolbarUpdate) {
+            updateTemplateToolbarState(block);
+          }
+          return;
+        }
+
+        const preset = noteStylePresets.find(item => item.id === styleId);
+        if (!preset) return;
+
+        const baseWidth = parseInt(block.dataset.borderWidth || target.style.borderTopWidth || '1', 10) || 1;
+        const accentExtra = Number.isFinite(preset.accentExtra) ? preset.accentExtra : 0;
+
+        target.style.backgroundColor = preset.background;
+        target.style.color = preset.text;
+        target.style.borderStyle = 'solid';
+        target.style.borderColor = preset.border;
+        target.style.borderWidth = baseWidth + 'px';
+        target.style.borderLeftWidth = (baseWidth + accentExtra) + 'px';
+        target.style.borderLeftColor = preset.accent || preset.border;
+
+        block.dataset.bgColor = preset.background;
+        block.dataset.textColor = preset.text;
+        block.dataset.borderColor = preset.border;
+        block.dataset.accentColor = preset.accent || preset.border;
+        block.dataset.borderAccentExtra = String(accentExtra);
+        block.dataset.noteStyle = preset.id;
+        updateBorderWidthDataset(block, baseWidth, accentExtra);
+
+        if (!options.skipToolbarUpdate) {
+          updateTemplateToolbarState(block);
+        }
+      }
+
       function applyTemplateBackground(color) {
         if (!selectedTemplateBlock) return;
         const target = getTemplateTarget(selectedTemplateBlock);
         if (!target) return;
+        markNoteStyleAsCustom(selectedTemplateBlock);
         if (!color || color === 'transparent') {
           target.style.backgroundColor = 'transparent';
           delete selectedTemplateBlock.dataset.bgColor;
@@ -3007,6 +3342,7 @@
         if (!selectedTemplateBlock) return;
         const target = getTemplateTarget(selectedTemplateBlock);
         if (!target) return;
+        markNoteStyleAsCustom(selectedTemplateBlock);
         if (!color) {
           target.style.color = '';
           delete selectedTemplateBlock.dataset.textColor;
@@ -3028,6 +3364,7 @@
         if (!selectedTemplateBlock) return;
         const target = getTemplateTarget(selectedTemplateBlock);
         if (!target || !target.classList.contains('box')) return;
+        markNoteStyleAsCustom(selectedTemplateBlock);
         const normalized = color || '#ced4da';
         target.style.borderStyle = 'solid';
         target.style.borderColor = normalized;
@@ -3046,6 +3383,7 @@
         if (!selectedTemplateBlock) return;
         const target = getTemplateTarget(selectedTemplateBlock);
         if (!target || !target.classList.contains('box')) return;
+        markNoteStyleAsCustom(selectedTemplateBlock);
         const normalized = color || selectedTemplateBlock.dataset.borderColor || '#0d6efd';
         target.style.borderLeftColor = normalized;
         selectedTemplateBlock.dataset.accentColor = normalized;
@@ -3152,6 +3490,33 @@
           } else if (!shouldShowAccent) {
             delete block.dataset.accentColor;
           }
+        }
+
+        if (templateStyleRow) {
+          templateStyleRow.style.display = isNote ? 'flex' : 'none';
+        }
+
+        if (templateSpacingRow) {
+          templateSpacingRow.style.display = isNote ? 'flex' : 'none';
+        }
+
+        if (templateStyleSelect) {
+          templateStyleSelect.disabled = !isNote;
+          if (isNote) {
+            const storedStyle = block.dataset.noteStyle || '';
+            const valid = noteStylePresets.some(preset => preset.id === storedStyle);
+            templateStyleSelect.value = valid ? storedStyle : '';
+          } else {
+            templateStyleSelect.value = '';
+          }
+        }
+
+        if (templateSpaceBeforeBtn) {
+          templateSpaceBeforeBtn.disabled = !isNote;
+        }
+
+        if (templateSpaceAfterBtn) {
+          templateSpaceAfterBtn.disabled = !isNote;
         }
       }
 
@@ -4320,7 +4685,7 @@
           if (m) {
             const json = JSON.parse('{' + m[1] + '}');
             if (json.especialidad && specialtySpan) {
-              specialtySpan.textContent = json.especialidad;
+              specialtySpan.dataset.specialty = json.especialidad;
             }
           }
         } catch (e) {}
@@ -4369,7 +4734,7 @@
             magicIcon.addEventListener('click', (e) => {
               e.stopPropagation();
               closePanel();
-              activateMagicTopic(magicAnchorFor(page), getTitle());
+              activateMagicTopic(magicAnchorFor(page), getTitle(), page);
             });
             magicIcon.dataset.bound = 'true';
           }
@@ -4466,7 +4831,7 @@
 
       /* === EXPORTAR MARKDOWN === */
       exportMarkdownBtn?.addEventListener('click', () => {
-        let markdown = `# ${specialtySpan?.textContent || 'Documento'}\n\n`;
+        let markdown = `# ${specialtySpan?.dataset?.specialty || 'Documento'}\n\n`;
         
         pages.forEach(page => {
           const clone = page.cloneNode(true);
@@ -4477,7 +4842,7 @@
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
-        const specialty = specialtySpan?.textContent || 'documento';
+        const specialty = specialtySpan?.dataset?.specialty || 'documento';
         const timestamp = new Date().toISOString().slice(0, 10).replace(/-/g, '');
         a.download = `${specialty.toLowerCase().replace(/\s+/g, '-')}-${timestamp}.md`;
         document.body.appendChild(a);
@@ -4951,6 +5316,19 @@
         applyTemplateAccentColor(e.target.value || '#0d6efd');
       });
 
+      templateStyleSelect?.addEventListener('change', (e) => {
+        if (!selectedTemplateBlock) return;
+        const value = (e.target.value || '').trim();
+        if (value) {
+          applyNoteStylePreset(selectedTemplateBlock, value);
+        } else {
+          applyNoteStylePreset(selectedTemplateBlock, '');
+        }
+      });
+
+      templateSpaceBeforeBtn?.addEventListener('click', () => insertTemplateSpacer('before'));
+      templateSpaceAfterBtn?.addEventListener('click', () => insertTemplateSpacer('after'));
+
       templateBorderWidthSlider?.addEventListener('input', (e) => {
         if (!selectedTemplateBlock) return;
         const target = getTemplateTarget(selectedTemplateBlock);
@@ -5380,14 +5758,17 @@
         const templates = [
           {
             name: 'Nota Importante',
-            html: '<div class="box" style="border-left-color: #dc3545;"><strong>Nota importante:</strong> Escribe tu contenido aquí.</div>'
+            noteStyle: 'note-soft-rose',
+            html: '<div class="box"><strong>Nota importante:</strong> Escribe tu contenido aquí.</div>'
           },
           {
             name: 'Perla Clínica',
+            noteStyle: 'note-soft-violet',
             html: '<div class="box pearl">Escribe tu perla clínica aquí.</div>'
           },
           {
             name: 'Cuadro Informativo',
+            noteStyle: 'note-classic',
             html: '<div class="box"><strong>Título:</strong><p>Contenido del cuadro informativo.</p></div>'
           },
           {
@@ -5404,11 +5785,13 @@
           },
           {
             name: 'Nota de Advertencia',
-            html: '<div class="box" style="background: #fff3cd; border-left-color: #ffc107;"><strong>⚠️ Advertencia:</strong> Contenido importante de advertencia.</div>'
+            noteStyle: 'note-soft-amber',
+            html: '<div class="box"><strong>⚠️ Advertencia:</strong> Contenido importante de advertencia.</div>'
           },
           {
             name: 'Nota de Éxito',
-            html: '<div class="box" style="background: #d1e7dd; border-left-color: #198754;"><strong>✓ Éxito:</strong> Información positiva o exitosa.</div>'
+            noteStyle: 'note-soft-green',
+            html: '<div class="box"><strong>✓ Éxito:</strong> Información positiva o exitosa.</div>'
           },
           {
             name: 'Lista de Verificación',
@@ -5424,7 +5807,8 @@
           },
           {
             name: 'Definición',
-            html: '<div class="box" style="background: #e7f3ff;"><strong>Definición:</strong> Término a definir - explicación del término.</div>'
+            noteStyle: 'note-soft-blue',
+            html: '<div class="box"><strong>Definición:</strong> Término a definir - explicación del término.</div>'
           }
         ];
 
@@ -5509,9 +5893,11 @@
 
       function closeMagicView() {
         document.body.classList.remove('magic-open');
+        magic.innerHTML = '';
+        magic.style.display = '';
       }
 
-      function activateMagicTopic(anchorId, title) {
+      function activateMagicTopic(anchorId, title, sourcePage) {
         magic.innerHTML =
           '<div class="magic-header"><strong>✨ Visor del tema</strong><button class="magic-close">&times;</button></div>';
         const magicPage = document.createElement('div');
@@ -5528,6 +5914,8 @@
         afterContentSanitize(wrapper);
 
         magicPage.appendChild(wrapper);
+        const sourceTheme = sourcePage?.dataset?.theme || '';
+        applyThemeToMagicPage(magicPage, sourceTheme);
         magic.appendChild(magicPage);
 
         if (isEditMode) {
@@ -5542,7 +5930,9 @@
           closeMagicView();
         });
 
+        magic.style.display = 'flex';
         document.body.classList.add('magic-open');
+        updateMagicZoom();
       }
 
       function buildSectionsPanel() {
@@ -5794,13 +6184,30 @@
       const io = new IntersectionObserver((entries) => {
         const visible = entries.filter(e => e.isIntersecting).sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
         if (!visible) return;
+        activePage = visible.target;
+        if (activePage.dataset.theme) {
+          setPageTheme(activePage, activePage.dataset.theme);
+        }
+        updateActiveThemeContext(activePage);
+        updateTopbarContext(activePage);
+        syncThemeSelectWithPage(activePage);
         const tid = visible.target.dataset.topicId || '';
-        sectionsContainer.querySelectorAll('li').forEach(li => 
+        sectionsContainer.querySelectorAll('li').forEach(li =>
           li.classList.toggle('active', li.dataset.topicId === tid)
         );
       }, { root: null, threshold: [0.5, 0.75, 1] });
-      
-      pages.forEach(p => io.observe(p));
+
+      pages.forEach(p => {
+        io.observe(p);
+        if (p.dataset.theme) {
+          setPageTheme(p, p.dataset.theme);
+        }
+      });
+
+      activePage = getCurrentPage();
+      updateActiveThemeContext(activePage);
+      updateTopbarContext(activePage);
+      syncThemeSelectWithPage(activePage);
 
       plusBtn?.addEventListener('click', () => {
         if (panel.classList.contains('open')) {
@@ -5835,15 +6242,13 @@
       });
 
       /* === TEMA DE COLORES === */
-      document.getElementById('themeSelect')?.addEventListener('change', function() {
-        const oldTheme = document.body.className.split(' ').find(c => c.startsWith('theme-'));
-        if (oldTheme) {
-          document.body.classList.remove(oldTheme);
-        }
-        document.body.classList.add(this.value);
-        if (isReadingMode) {
-          document.body.classList.add('reading-mode');
-        }
+      themeSelect?.addEventListener('change', function() {
+        const page = getCurrentPage();
+        if (!page) return;
+        setPageTheme(page, this.value || '');
+        activePage = page;
+        updateActiveThemeContext(page);
+        syncThemeSelectWithPage(page);
       });
 
       /* === EDICIÓN === */
@@ -6084,7 +6489,8 @@
     const tempPage = page.cloneNode(true);
     tempPage.contentEditable = 'false';
 
-    const currentTheme = document.body.className.split(' ').find(c => c.startsWith('theme-')) || 'theme-blue';
+    const pageThemeName = getPageTheme(page) || 'theme-blue';
+    const themeVars = getThemeDefinition(pageThemeName);
 
     const htmlDoc = `<!DOCTYPE html>
 <html lang="es">
@@ -6093,10 +6499,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>${title}</title>
   <style>
-${document.querySelector('style').textContent}
+  ${document.querySelector('style').textContent}
   </style>
 </head>
-<body class="${currentTheme}">
+<body style="--theme-primary:${themeVars.primary};--theme-primary-dark:${themeVars.dark};--theme-primary-light:${themeVars.light};">
   ${magicContent ? '<div class="magic-content-container" style="display:none">' + magicContent.outerHTML + '</div>' : ''}
   ${tempPage.outerHTML}
 </body>
@@ -6268,6 +6674,7 @@ ${document.querySelector('style').textContent}
           html: page.innerHTML,
           sectionId: page.dataset.sectionId,
           sectionName: page.dataset.sectionName,
+          theme: getPageTheme(page) || '',
           magicId: magicId || null,
           magicHtml: magicEl ? magicEl.innerHTML : null
         });
@@ -6306,13 +6713,14 @@ ${document.querySelector('style').textContent}
         html: page.innerHTML,
         sectionId: sectionId,
         sectionName: sectionName,
+        theme: getPageTheme(page) || '',
         magicId: magicId || null,
         magicHtml: magicEl ? magicEl.innerHTML : null
       });
     });
 
     return {
-      specialty: specialtySpan?.textContent || '',
+      specialty: specialtySpan?.dataset?.specialty || '',
       sections: exportedSections,
       magicContainerHtml: magicContainer ? magicContainer.innerHTML : ''
     };
@@ -6414,7 +6822,8 @@ ${document.querySelector('style').textContent}
     pages.forEach(page => page.remove());
 
     if (specialtySpan && typeof data.specialty === 'string') {
-      specialtySpan.textContent = data.specialty;
+      specialtySpan.dataset.specialty = data.specialty;
+      updateTopbarContext(activePage);
     }
 
     const magicContainer = document.querySelector('.magic-content-container');
@@ -6445,6 +6854,11 @@ ${document.querySelector('style').textContent}
         mainContainer.insertBefore(page, scriptTag);
         afterContentSanitize(page);
         page.contentEditable = isEditMode ? 'true' : 'false';
+        if (typeof topicData?.theme === 'string') {
+          setPageTheme(page, topicData.theme);
+        } else {
+          setPageTheme(page, page.dataset.theme || '');
+        }
 
         const title = (topicData?.titulo && String(topicData.titulo).trim()) || getTopicTitle(page) || `Tema ${sectionInfo.temas.length + 1}`;
         sectionInfo.temas.push({ id: topicId, titulo: title, page });
@@ -6474,7 +6888,12 @@ ${document.querySelector('style').textContent}
     allSectionsExpanded = sections.every(section => !section.collapsed);
     globalTopicCounter = 1;
 
-    pages.forEach(page => io.observe(page));
+    pages.forEach(page => {
+      io.observe(page);
+      if (page.dataset.theme) {
+        setPageTheme(page, page.dataset.theme);
+      }
+    });
     setupMagicIcons();
     buildSectionsPanel();
     buildTableOfContents();
@@ -6484,6 +6903,10 @@ ${document.querySelector('style').textContent}
     hideImageToolbar();
     hideTemplateToolbar();
     savedSelection = null;
+    activePage = getCurrentPage();
+    updateActiveThemeContext(activePage);
+    updateTopbarContext(activePage);
+    syncThemeSelectWithPage(activePage);
     window.scrollTo({ top: 0 });
   }
 
@@ -6548,7 +6971,7 @@ ${document.querySelector('style').textContent}
     }
 
     const buildData = {
-      especialidad: specialtySpan?.textContent || 'documento',
+      especialidad: specialtySpan?.dataset?.specialty || 'documento',
       secciones: sections.map(sec => ({
         id: sec.id,
         nombre: sec.nombre,
@@ -6576,7 +6999,7 @@ ${document.querySelector('style').textContent}
     const a = document.createElement('a');
     a.href = url;
     
-    const specialty = specialtySpan?.textContent || 'documento';
+    const specialty = specialtySpan?.dataset?.specialty || 'documento';
     const timestamp = new Date().toISOString().slice(0, 10).replace(/-/g, '');
     const filename = `${specialty.toLowerCase().replace(/\s+/g, '-')}-${timestamp}.html`;
     a.download = filename;
@@ -6625,7 +7048,8 @@ ${document.querySelector('style').textContent}
 
           const loadedSpecialty = loadedDoc.getElementById('specialtyTitle');
           if (loadedSpecialty && specialtySpan && loadedSpecialty.textContent.trim()) {
-            specialtySpan.textContent = loadedSpecialty.textContent.trim();
+            specialtySpan.dataset.specialty = loadedSpecialty.textContent.trim();
+            updateTopbarContext(activePage);
           }
 
           const mainContainer = document.querySelector('body');
@@ -6663,6 +7087,11 @@ ${document.querySelector('style').textContent}
             }
             existingTopicIds.add(topicId);
 
+            if (clonedPage.dataset.theme) {
+              setPageTheme(clonedPage, clonedPage.dataset.theme);
+            } else {
+              setPageTheme(clonedPage, '');
+            }
             clonedPage.contentEditable = isEditMode ? 'true' : 'false';
             mainContainer.insertBefore(clonedPage, scriptTag);
           });
@@ -6724,6 +7153,9 @@ ${document.querySelector('style').textContent}
         if (!p.dataset.topicId) {
           p.dataset.topicId = 'topic-' + Date.now() + '-' + Math.random().toString(36).substr(2, 9);
         }
+        if (p.dataset.theme) {
+          setPageTheme(p, p.dataset.theme);
+        }
         io.observe(p);
       });
 
@@ -6731,6 +7163,10 @@ ${document.querySelector('style').textContent}
       initializeSections();
       buildSectionsPanel();
       buildTableOfContents();
+      activePage = getCurrentPage();
+      updateActiveThemeContext(activePage);
+      updateTopbarContext(activePage);
+      syncThemeSelectWithPage(activePage);
 
       if (isEditMode) {
         pages.forEach(page => page.contentEditable = 'true');


### PR DESCRIPTION
## Summary
- keep the top bar topic label in sync with the visible page and hide it by default
- add soft table themes, note style presets, spacer controls, and resizable note blocks
- ensure the magic notes viewer opens reliably with independent zooming and per-page themes

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e604559088832ca3a5cccfc567fe54