### PR TITLE
Add bulk clear action and improve topic tooling

### DIFF
--- a/index.html
+++ b/index.html
@@ -6288,18 +6288,32 @@
       }
 
       function magicAnchorFor(page) {
-        const tid = page.dataset.topicId || '';
-        if (!tid) return '';
-        
-        if (document.getElementById(`magic-topic-${tid}`)) {
-          return `magic-topic-${tid}`;
+        if (!page) return '';
+
+        const storedAnchor = page.dataset.magicAnchorId?.trim();
+        if (storedAnchor) {
+          const storedEl = document.getElementById(storedAnchor);
+          if (storedEl) {
+            return storedAnchor;
+          }
+          delete page.dataset.magicAnchorId;
         }
-        if (document.getElementById(`magic-${tid}`)) {
-          return `magic-${tid}`;
+
+        const tid = (page.dataset.topicId || '').trim();
+        if (!tid) {
+          return '';
         }
-        if (document.getElementById(tid)) {
-          return tid;
+
+        const candidates = [`magic-topic-${tid}`, `magic-${tid}`, tid];
+        for (const candidate of candidates) {
+          if (!candidate) continue;
+          const el = document.getElementById(candidate);
+          if (el) {
+            page.dataset.magicAnchorId = candidate;
+            return candidate;
+          }
         }
+
         return '';
       }
 
@@ -7303,7 +7317,10 @@ ${document.querySelector('style').textContent}
       magicContainer.innerHTML = '';
       if (Array.isArray(data.magicTopics) && data.magicTopics.length) {
         data.magicTopics.forEach(topicInfo => {
-          const topicId = topicInfo?.id ? String(topicInfo.id) : generateUniqueId('magic-topic');
+          let topicId = topicInfo?.id ? String(topicInfo.id).trim() : '';
+          if (!topicId) {
+            topicId = generateUniqueId('magic-topic');
+          }
           const magicTopic = document.createElement('div');
           magicTopic.id = topicId;
           magicTopic.className = 'magic-topic';
@@ -7317,7 +7334,13 @@ ${document.querySelector('style').textContent}
         magicContainer.querySelectorAll('.magic-topic').forEach(topic => {
           afterContentSanitize(topic);
           if (topic.id) {
-            magicTopicMap.set(topic.id, topic);
+            const trimmedId = topic.id.trim();
+            if (trimmedId && trimmedId !== topic.id) {
+              topic.id = trimmedId;
+            }
+            if (trimmedId) {
+              magicTopicMap.set(trimmedId, topic);
+            }
           }
         });
       }
@@ -7357,10 +7380,11 @@ ${document.querySelector('style').textContent}
         sectionInfo.temas.push({ id: topicId, titulo: title, page });
         newPages.push(page);
 
+        let resolvedMagicId = '';
         if (magicContainer) {
           let magicId = '';
           if (topicData?.magicId) {
-            magicId = String(topicData.magicId);
+            magicId = String(topicData.magicId).trim();
           } else if (typeof topicData?.magicHtml === 'string') {
             magicId = `magic-topic-${topicId}`;
           }
@@ -7378,7 +7402,16 @@ ${document.querySelector('style').textContent}
               magicTopic.innerHTML = topicData.magicHtml;
               afterContentSanitize(magicTopic);
             }
+            resolvedMagicId = magicId;
           }
+        }
+
+        if (resolvedMagicId) {
+          page.dataset.magicAnchorId = resolvedMagicId;
+        } else if (topicData?.magicId) {
+          page.dataset.magicAnchorId = String(topicData.magicId).trim();
+        } else {
+          delete page.dataset.magicAnchorId;
         }
       });
 

--- a/index.html
+++ b/index.html
@@ -3168,8 +3168,7 @@
       function syncMagicZoom() {
         if (!magic) return;
         if (isMagicViewActive) {
-          const scale = currentZoom ? (1 / currentZoom) : 1;
-          magic.style.setProperty('--magic-zoom', scale.toString());
+          magic.style.setProperty('--magic-zoom', '1');
         } else {
           magic.style.removeProperty('--magic-zoom');
         }
@@ -6298,6 +6297,14 @@
         hideTopicMenu();
       }
 
+      const escapeAttr = (value) => {
+        if (typeof value !== 'string') return '';
+        if (window.CSS && typeof window.CSS.escape === 'function') {
+          return window.CSS.escape(value);
+        }
+        return value.replace(/[^a-zA-Z0-9_\-]/g, (char) => `\\${char}`);
+      };
+
       function magicAnchorFor(page) {
         if (!page) return '';
 
@@ -6305,6 +6312,12 @@
         if (storedAnchor) {
           const storedEl = document.getElementById(storedAnchor);
           if (storedEl) {
+            if (storedEl.classList.contains('magic-topic')) {
+              const tid = (page.dataset.topicId || '').trim();
+              if (tid) {
+                storedEl.dataset.sourceTopicId = tid;
+              }
+            }
             return storedAnchor;
           }
           delete page.dataset.magicAnchorId;
@@ -6320,8 +6333,21 @@
           if (!candidate) continue;
           const el = document.getElementById(candidate);
           if (el) {
+            if (el.classList.contains('magic-topic')) {
+              el.dataset.sourceTopicId = tid;
+            }
             page.dataset.magicAnchorId = candidate;
             return candidate;
+          }
+        }
+
+        const container = document.querySelector('.magic-content-container');
+        if (container) {
+          const selector = `.magic-topic[data-source-topic-id="${escapeAttr(tid)}"]`;
+          const el = container.querySelector(selector);
+          if (el && el.id) {
+            page.dataset.magicAnchorId = el.id;
+            return el.id;
           }
         }
 
@@ -7118,9 +7144,14 @@ ${document.querySelector('style').textContent}
           topicId = generateUniqueId('magic-topic');
           topic.id = topicId;
         }
+        const sourceTopicId = (topic.dataset.sourceTopicId || '').trim();
+        if (sourceTopicId) {
+          topic.dataset.sourceTopicId = sourceTopicId;
+        }
         exportedMagicTopics.push({
           id: topicId,
-          html: topic.innerHTML
+          html: topic.innerHTML,
+          sourceTopicId: sourceTopicId || null
         });
       });
     }
@@ -7159,6 +7190,9 @@ ${document.querySelector('style').textContent}
         const titleText = (tema.titulo || getTopicTitle(page) || '').trim() || `Tema ${exportSection.temas.length + 1}`;
         const magicId = magicAnchorFor(page);
         const magicEl = magicId ? document.getElementById(magicId) : null;
+        if (magicEl && topicId) {
+          magicEl.dataset.sourceTopicId = topicId;
+        }
 
         const templateBlocks = serializeTemplateBlocks(page);
         const topicExport = {
@@ -7206,6 +7240,9 @@ ${document.querySelector('style').textContent}
 
       const magicId = magicAnchorFor(page);
       const magicEl = magicId ? document.getElementById(magicId) : null;
+      if (magicEl && topicId) {
+        magicEl.dataset.sourceTopicId = topicId;
+      }
 
       const templateBlocks = serializeTemplateBlocks(page);
       const topicExport = {
@@ -7336,6 +7373,7 @@ ${document.querySelector('style').textContent}
 
     const magicContainer = document.querySelector('.magic-content-container');
     const magicTopicMap = new Map();
+    const magicTopicBySource = new Map();
     if (magicContainer) {
       magicContainer.innerHTML = '';
       if (Array.isArray(data.magicTopics) && data.magicTopics.length) {
@@ -7344,6 +7382,7 @@ ${document.querySelector('style').textContent}
           if (!topicId) {
             topicId = generateUniqueId('magic-topic');
           }
+          const sourceTopicId = topicInfo?.sourceTopicId ? String(topicInfo.sourceTopicId).trim() : '';
           const magicTopic = document.createElement('div');
           magicTopic.id = topicId;
           magicTopic.className = 'magic-topic';
@@ -7351,6 +7390,10 @@ ${document.querySelector('style').textContent}
           magicContainer.appendChild(magicTopic);
           afterContentSanitize(magicTopic);
           magicTopicMap.set(topicId, magicTopic);
+          if (sourceTopicId) {
+            magicTopic.dataset.sourceTopicId = sourceTopicId;
+            magicTopicBySource.set(sourceTopicId, magicTopic);
+          }
         });
       } else if (typeof data.magicContainerHtml === 'string') {
         magicContainer.innerHTML = data.magicContainerHtml;
@@ -7364,6 +7407,11 @@ ${document.querySelector('style').textContent}
             if (trimmedId) {
               magicTopicMap.set(trimmedId, topic);
             }
+          }
+          const sourceTopicId = (topic.dataset.sourceTopicId || '').trim();
+          if (sourceTopicId) {
+            topic.dataset.sourceTopicId = sourceTopicId;
+            magicTopicBySource.set(sourceTopicId, topic);
           }
         });
       }
@@ -7382,7 +7430,8 @@ ${document.querySelector('style').textContent}
       const topics = Array.isArray(sectionData?.temas) ? sectionData.temas : [];
 
       topics.forEach(topicData => {
-        const topicId = topicData?.id ? String(topicData.id) : generateUniqueId('topic');
+        let topicId = topicData?.id ? String(topicData.id) : generateUniqueId('topic');
+        topicId = topicId.trim();
         const topicSectionName = topicData?.sectionName ? String(topicData.sectionName) : sectionName;
         const page = document.createElement('section');
         page.className = 'page';
@@ -7405,34 +7454,75 @@ ${document.querySelector('style').textContent}
 
         let resolvedMagicId = '';
         if (magicContainer) {
-          let magicId = '';
-          if (topicData?.magicId) {
-            magicId = String(topicData.magicId).trim();
-          } else if (typeof topicData?.magicHtml === 'string') {
-            magicId = `magic-topic-${topicId}`;
+          const desiredMagicId = topicData?.magicId ? String(topicData.magicId).trim() : '';
+          let magicTopic = desiredMagicId ? magicTopicMap.get(desiredMagicId) : null;
+
+          if (!magicTopic && desiredMagicId) {
+            const existing = document.getElementById(desiredMagicId);
+            if (existing && existing.classList.contains('magic-topic')) {
+              magicTopic = existing;
+              magicTopicMap.set(desiredMagicId, magicTopic);
+            }
           }
 
-          if (magicId) {
-            let magicTopic = magicTopicMap.get(magicId);
-            if (!magicTopic) {
-              magicTopic = document.createElement('div');
-              magicTopic.id = magicId;
-              magicTopic.className = 'magic-topic';
-              magicContainer.appendChild(magicTopic);
-              magicTopicMap.set(magicId, magicTopic);
+          if (!magicTopic) {
+            magicTopic = magicTopicBySource.get(topicId);
+          }
+
+          if (!magicTopic && typeof topicData?.magicHtml === 'string') {
+            let baseId = desiredMagicId || `magic-topic-${topicId}`;
+            baseId = baseId.trim();
+            if (!baseId) {
+              baseId = generateUniqueId('magic-topic');
+            }
+            let uniqueId = baseId;
+            while (uniqueId && (magicTopicMap.has(uniqueId) || document.getElementById(uniqueId))) {
+              uniqueId = `${baseId}-${Math.random().toString(36).slice(2, 6)}`;
+            }
+            magicTopic = document.createElement('div');
+            magicTopic.id = uniqueId;
+            magicTopic.className = 'magic-topic';
+            magicContainer.appendChild(magicTopic);
+            magicTopicMap.set(uniqueId, magicTopic);
+          }
+
+          if (magicTopic) {
+            if (!magicTopic.id) {
+              let fallbackId = desiredMagicId || `magic-topic-${topicId || generateUniqueId('magic-topic')}`;
+              fallbackId = (fallbackId || '').trim();
+              if (!fallbackId) {
+                fallbackId = generateUniqueId('magic-topic');
+              }
+              let finalId = fallbackId;
+              while (finalId && (magicTopicMap.has(finalId) || document.getElementById(finalId))) {
+                finalId = `${fallbackId}-${Math.random().toString(36).slice(2, 6)}`;
+              }
+              magicTopic.id = finalId;
             }
             if (typeof topicData.magicHtml === 'string') {
               magicTopic.innerHTML = topicData.magicHtml;
               afterContentSanitize(magicTopic);
             }
-            resolvedMagicId = magicId;
+            if (topicId) {
+              magicTopic.dataset.sourceTopicId = topicId;
+              magicTopicBySource.set(topicId, magicTopic);
+            }
+            if (!magicTopicMap.has(magicTopic.id)) {
+              magicTopicMap.set(magicTopic.id, magicTopic);
+            }
+            resolvedMagicId = magicTopic.id;
           }
         }
 
         if (resolvedMagicId) {
           page.dataset.magicAnchorId = resolvedMagicId;
         } else if (topicData?.magicId) {
-          page.dataset.magicAnchorId = String(topicData.magicId).trim();
+          const fallbackMagicId = String(topicData.magicId).trim();
+          if (fallbackMagicId) {
+            page.dataset.magicAnchorId = fallbackMagicId;
+          } else {
+            delete page.dataset.magicAnchorId;
+          }
         } else {
           delete page.dataset.magicAnchorId;
         }
@@ -7650,6 +7740,12 @@ ${document.querySelector('style').textContent}
               loadedMagicContainer.querySelectorAll('.magic-topic').forEach(topic => {
                 const clonedTopic = topic.cloneNode(true);
                 afterContentSanitize(clonedTopic);
+                const sourceTopicId = (clonedTopic.dataset.sourceTopicId || '').trim();
+                if (sourceTopicId) {
+                  clonedTopic.dataset.sourceTopicId = sourceTopicId;
+                } else {
+                  delete clonedTopic.dataset.sourceTopicId;
+                }
                 magicContainer.appendChild(clonedTopic);
               });
             }

--- a/index.html
+++ b/index.html
@@ -2696,6 +2696,9 @@
       let selectedImage = null;
       let selectedTemplateBlock = null;
       let currentZoom = 1;
+      let lastRegularZoom = 1;
+      let zoomBeforeMagic = null;
+      let isMagicViewActive = false;
       let allSectionsExpanded = true;
       let savedSelection = null;
       let tableMenuAPI = null;
@@ -3164,14 +3167,22 @@
       /* === ZOOM === */
       function syncMagicZoom() {
         if (!magic) return;
-        const scale = currentZoom ? (1 / currentZoom) : 1;
-        magic.style.setProperty('--magic-zoom', scale.toString());
+        if (isMagicViewActive) {
+          const scale = currentZoom ? (1 / currentZoom) : 1;
+          magic.style.setProperty('--magic-zoom', scale.toString());
+        } else {
+          magic.style.removeProperty('--magic-zoom');
+        }
       }
 
-      function applyZoom(level) {
+      function applyZoom(level, options = {}) {
+        const { skipRemember = false } = options;
         currentZoom = Math.max(0.5, Math.min(2, level));
         document.documentElement.style.setProperty('--zoom-level', currentZoom);
         zoomValue.textContent = Math.round(currentZoom * 100) + '%';
+        if (!skipRemember && !isMagicViewActive) {
+          lastRegularZoom = currentZoom;
+        }
         syncMagicZoom();
       }
 
@@ -6318,14 +6329,26 @@
       }
 
       function closeMagicView() {
+        if (isMagicViewActive) {
+          const restoreZoom = zoomBeforeMagic ?? lastRegularZoom ?? 1;
+          isMagicViewActive = false;
+          zoomBeforeMagic = null;
+          applyZoom(restoreZoom);
+        }
         document.body.classList.remove('magic-open');
         if (!magic) return;
         magic.classList.remove('open');
         magic.style.removeProperty('--magic-zoom');
+        zoomBeforeMagic = null;
       }
 
       function activateMagicTopic(anchorId, title) {
         if (!magic) return;
+        if (!isMagicViewActive) {
+          zoomBeforeMagic = currentZoom;
+        }
+        isMagicViewActive = true;
+        applyZoom(1, { skipRemember: true });
         magic.innerHTML =
           '<div class="magic-header"><strong>✨ Visor del tema</strong><button class="magic-close">&times;</button></div>';
         const magicPage = document.createElement('div');
@@ -7219,7 +7242,7 @@ ${document.querySelector('style').textContent}
       const snapshot = {
         version: 1,
         savedAt: new Date().toISOString(),
-        zoom: currentZoom,
+        zoom: isMagicViewActive ? lastRegularZoom : currentZoom,
         data: collectDocumentData()
       };
 

--- a/index.html
+++ b/index.html
@@ -439,6 +439,24 @@
       text-align: right;
     }
 
+    .image-size-controls {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex: 1;
+    }
+
+    .image-size-btn {
+      width: 28px;
+      height: 28px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.1rem;
+      line-height: 1;
+      padding: 0;
+    }
+
     /* ===== Plantillas ===== */
     .template-block {
       display: block;
@@ -2263,6 +2281,7 @@
       <button class="topbar-btn" id="loadHtmlBtn" title="Cargar archivo HTML"><span>📂</span> <span class="topbar-btn-label">Abrir</span></button>
       <button class="topbar-btn" id="editBtn" title="Modo edición"><span>✏️</span> <span class="topbar-btn-label">Editar</span></button>
       <button class="topbar-btn" id="saveHtmlBtn" style="display:none;" title="Guardar como HTML"><span>💾</span> <span class="topbar-btn-label">Guardar</span></button>
+      <button class="topbar-btn" id="clearAllBtn" title="Eliminar todas las secciones y temas" aria-label="Eliminar todo"><span>🗑️</span></button>
       <button class="topbar-btn" id="exportDataBtn" title="Exportar secciones y temas" aria-label="Exportar secciones y temas"><span>📤</span></button>
       <button class="topbar-btn" id="importDataBtn" title="Importar secciones y temas" aria-label="Importar secciones y temas"><span>📥</span></button>
       <button class="topbar-btn" id="exportMarkdownBtn" title="Exportar a Markdown"><span>⬇️</span> <span class="topbar-btn-label">MD</span></button>
@@ -2396,8 +2415,11 @@
     </div>
     <div class="image-toolbar-row">
       <label>Ancho:</label>
-      <input type="range" id="imageWidthSlider" min="50" max="900" step="1">
-      <span class="size-display" id="widthDisplay">200px</span>
+      <div class="image-size-controls">
+        <button type="button" class="image-size-btn" id="imageWidthDecrease" title="Reducir tamaño">−</button>
+        <span class="size-display" id="widthDisplay">100% (200px)</span>
+        <button type="button" class="image-size-btn" id="imageWidthIncrease" title="Aumentar tamaño">+</button>
+      </div>
     </div>
     <div class="image-toolbar-row">
       <label>Alto:</label>
@@ -2687,6 +2709,10 @@
         scaleY: 1
       };
 
+      const IMAGE_MIN_WIDTH = 60;
+      const IMAGE_MAX_WIDTH = 1600;
+      const IMAGE_RESIZE_STEP = 0.1;
+
       const CACHE_STORAGE_KEY = 'emi2025-editor-cache-v1';
 
       let sections = [];
@@ -2714,6 +2740,7 @@
       const loadHtmlInput = document.getElementById('loadHtmlInput');
       const editToolbar = document.getElementById('editToolbar');
       const statsBtn = document.getElementById('statsBtn');
+      const clearAllBtn = document.getElementById('clearAllBtn');
       const exportDataBtn = document.getElementById('exportDataBtn');
       const importDataBtn = document.getElementById('importDataBtn');
       const importDataInput = document.getElementById('importDataInput');
@@ -2730,6 +2757,11 @@
       const wrapFigureBtn = document.getElementById('wrapFigureBtn');
       const unwrapFigureBtn = document.getElementById('unwrapFigureBtn');
       const cropImageBtn = document.getElementById('cropImageBtn');
+      const imageWidthIncreaseBtn = document.getElementById('imageWidthIncrease');
+      const imageWidthDecreaseBtn = document.getElementById('imageWidthDecrease');
+      const widthDisplay = document.getElementById('widthDisplay');
+      const heightSlider = document.getElementById('imageHeightSlider');
+      const heightDisplay = document.getElementById('heightDisplay');
       const imageCropModal = document.getElementById('imageCropModal');
       const imageCropStage = document.getElementById('imageCropStage');
       const imageCropPreview = document.getElementById('imageCropPreview');
@@ -5228,6 +5260,72 @@
         }
       }
 
+      function getImageNaturalWidth(img) {
+        if (!img) return 0;
+        const attrWidth = parseFloat(img.getAttribute('width') || '');
+        const natural = img.naturalWidth || attrWidth || img.width || img.getBoundingClientRect().width || 0;
+        if (natural > 0) {
+          img.dataset.originalWidth = String(Math.round(natural));
+          return natural;
+        }
+        const stored = parseFloat(img.dataset.originalWidth || '');
+        if (!Number.isNaN(stored) && stored > 0) {
+          return stored;
+        }
+        return 0;
+      }
+
+      function getImageWidthPx(img) {
+        if (!img) return 0;
+        const styleWidth = parseFloat(img.style.width || '');
+        if (!Number.isNaN(styleWidth) && styleWidth > 0) {
+          return styleWidth;
+        }
+        if (img.width) {
+          return img.width;
+        }
+        const rectWidth = img.getBoundingClientRect().width;
+        if (rectWidth > 0) {
+          return rectWidth;
+        }
+        return getImageNaturalWidth(img) || 0;
+      }
+
+      function setImageWidthPx(img, width) {
+        if (!img) return 0;
+        const clamped = Math.max(IMAGE_MIN_WIDTH, Math.min(IMAGE_MAX_WIDTH, Math.round(width)));
+        img.style.width = clamped + 'px';
+        if (!img.style.height) {
+          img.style.height = 'auto';
+        }
+        return clamped;
+      }
+
+      function updateWidthDisplayForImage(img) {
+        if (!widthDisplay) return;
+        if (!img) {
+          widthDisplay.textContent = '';
+          return;
+        }
+        const current = getImageWidthPx(img);
+        const natural = getImageNaturalWidth(img);
+        const percent = natural > 0 ? Math.round((current / natural) * 100) : null;
+        const roundedWidth = Math.max(1, Math.round(current));
+        if (percent !== null && Number.isFinite(percent)) {
+          widthDisplay.textContent = `${percent}% (${roundedWidth}px)`;
+        } else {
+          widthDisplay.textContent = `${roundedWidth}px`;
+        }
+      }
+
+      function changeSelectedImageWidth(multiplier) {
+        if (!selectedImage) return;
+        const current = getImageWidthPx(selectedImage) || getImageNaturalWidth(selectedImage) || 200;
+        setImageWidthPx(selectedImage, current * multiplier);
+        updateWidthDisplayForImage(selectedImage);
+        repositionImageToolbar();
+      }
+
       function updateToolbarPosition(img) {
         if (!imageToolbar || !img) return;
 
@@ -5281,19 +5379,7 @@
         const activeFloat = floatClasses.find(cls => container.classList.contains(cls));
         setActiveAlignButton(activeFloat);
 
-        const widthSlider = document.getElementById('imageWidthSlider');
-        const heightSlider = document.getElementById('imageHeightSlider');
-        const widthDisplay = document.getElementById('widthDisplay');
-        const heightDisplay = document.getElementById('heightDisplay');
-
-        if (widthSlider && widthDisplay) {
-          const widthValue = parseInt(img.style.width) || img.width || 200;
-          const sliderMax = parseInt(widthSlider.max || '900', 10);
-          const sliderMin = parseInt(widthSlider.min || '50', 10);
-          const clampedWidth = Math.max(sliderMin, Math.min(sliderMax, widthValue));
-          widthSlider.value = clampedWidth;
-          widthDisplay.textContent = widthValue + 'px';
-        }
+        updateWidthDisplayForImage(img);
 
         if (heightSlider && heightDisplay) {
           if (img.style.height && img.style.height !== 'auto') {
@@ -5591,20 +5677,21 @@
         toggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
       });
 
-      document.getElementById('imageWidthSlider')?.addEventListener('input', (e) => {
-        if (selectedImage) {
-          const width = parseInt(e.target.value);
-          selectedImage.style.width = width + 'px';
-          document.getElementById('widthDisplay').textContent = width + 'px';
-          repositionImageToolbar();
-        }
+      imageWidthIncreaseBtn?.addEventListener('click', () => {
+        changeSelectedImageWidth(1 + IMAGE_RESIZE_STEP);
       });
 
-      document.getElementById('imageHeightSlider')?.addEventListener('input', (e) => {
+      imageWidthDecreaseBtn?.addEventListener('click', () => {
+        changeSelectedImageWidth(1 - IMAGE_RESIZE_STEP);
+      });
+
+      heightSlider?.addEventListener('input', (e) => {
         if (selectedImage) {
           const height = parseInt(e.target.value);
           selectedImage.style.height = height + 'px';
-          document.getElementById('heightDisplay').textContent = height + 'px';
+          if (heightDisplay) {
+            heightDisplay.textContent = height + 'px';
+          }
           repositionImageToolbar();
         }
       });
@@ -6351,11 +6438,15 @@
           btnMain.className = 'topic-action';
           btnMain.title = 'Ir al tema';
           btnMain.textContent = '📄';
-          btnMain.addEventListener('click', () => {
+          const openTopic = () => {
+            if (!tema.page || !tema.page.isConnected) return;
             closeMagicView();
             closePanel();
+            closeTocPanel();
             tema.page.scrollIntoView({ behavior: 'smooth', block: 'start' });
-          });
+          };
+
+          btnMain.addEventListener('click', openTopic);
 
           const titleSpan = document.createElement('span');
           titleSpan.className = 'topic-title';
@@ -6366,7 +6457,11 @@
             event.stopPropagation();
             showTopicMenu(event, tema);
           });
-          titleSpan.addEventListener('click', (event) => event.stopPropagation());
+          titleSpan.addEventListener('click', (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            openTopic();
+          });
 
           li.appendChild(numSpan);
           li.appendChild(btnMain);
@@ -6411,7 +6506,7 @@
 
       function deleteSection(section) {
         if (!confirm(`¿Eliminar toda la sección "${section.nombre}" con ${section.temas.length} tema(s)?`)) return;
-        
+
         section.temas.forEach(tema => {
           tema.page.remove();
         });
@@ -6425,10 +6520,40 @@
         }
       }
 
+      function clearAllContent() {
+        if (!confirm('¿Eliminar todas las secciones, temas y contenido adicional? Esta acción no se puede deshacer.')) {
+          return;
+        }
+
+        closeMagicView();
+        hideTopicMenu();
+        closePanel();
+        closeTocPanel();
+        io.disconnect();
+        pages.forEach(page => page.remove());
+        pages = [];
+        sections = [];
+        sectionThemes = new Map();
+        allSectionsExpanded = true;
+        globalTopicCounter = 1;
+        currentPageRef = null;
+        currentSectionId = '';
+        savedSelection = null;
+        const magicContainer = document.querySelector('.magic-content-container');
+        if (magicContainer) {
+          magicContainer.innerHTML = '';
+        }
+        buildSectionsPanel();
+        buildTableOfContents();
+        setActivePage(null);
+        syncBodyTheme(DEFAULT_THEME);
+        updateSectionIndicator(null);
+      }
+
       function addNewSection() {
         const nombre = prompt('Nombre de la nueva sección:');
         if (!nombre || !nombre.trim()) return;
-        
+
         const newSection = {
           id: 'seccion-' + Date.now(),
           nombre: nombre.trim(),
@@ -6513,6 +6638,7 @@
       document.getElementById('sortAlphaBtn')?.addEventListener('click', sortSectionsAlpha);
       document.getElementById('sortNumBtn')?.addEventListener('click', sortSectionsNumeric);
       document.getElementById('printCurrentBtn')?.addEventListener('click', printCurrentTopic);
+      clearAllBtn?.addEventListener('click', clearAllContent);
 
       const io = new IntersectionObserver((entries) => {
         const visible = entries.filter(e => e.isIntersecting).sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
@@ -6946,6 +7072,21 @@ ${document.querySelector('style').textContent}
     const sectionMap = new Map();
     const seenPages = new Set();
     const exportedSections = [];
+    const exportedMagicTopics = [];
+
+    if (magicContainer) {
+      magicContainer.querySelectorAll('.magic-topic').forEach(topic => {
+        let topicId = (topic.id || '').trim();
+        if (!topicId) {
+          topicId = generateUniqueId('magic-topic');
+          topic.id = topicId;
+        }
+        exportedMagicTopics.push({
+          id: topicId,
+          html: topic.innerHTML
+        });
+      });
+    }
 
     sections.forEach(section => {
       const baseSectionId = section.id || section.temas.find(t => t.page)?.page?.dataset.sectionId || generateUniqueId('seccion');
@@ -7050,7 +7191,8 @@ ${document.querySelector('style').textContent}
     return {
       specialty: getDocumentTitle() || '',
       sections: exportedSections,
-      magicContainerHtml: magicContainer ? magicContainer.innerHTML : ''
+      magicContainerHtml: magicContainer ? magicContainer.innerHTML : '',
+      magicTopics: exportedMagicTopics
     };
   }
 
@@ -7156,9 +7298,29 @@ ${document.querySelector('style').textContent}
     sectionThemes = new Map();
 
     const magicContainer = document.querySelector('.magic-content-container');
-    if (magicContainer && typeof data.magicContainerHtml === 'string') {
-      magicContainer.innerHTML = data.magicContainerHtml;
-      magicContainer.querySelectorAll('.magic-topic').forEach(topic => afterContentSanitize(topic));
+    const magicTopicMap = new Map();
+    if (magicContainer) {
+      magicContainer.innerHTML = '';
+      if (Array.isArray(data.magicTopics) && data.magicTopics.length) {
+        data.magicTopics.forEach(topicInfo => {
+          const topicId = topicInfo?.id ? String(topicInfo.id) : generateUniqueId('magic-topic');
+          const magicTopic = document.createElement('div');
+          magicTopic.id = topicId;
+          magicTopic.className = 'magic-topic';
+          magicTopic.innerHTML = typeof topicInfo?.html === 'string' ? topicInfo.html : '';
+          magicContainer.appendChild(magicTopic);
+          afterContentSanitize(magicTopic);
+          magicTopicMap.set(topicId, magicTopic);
+        });
+      } else if (typeof data.magicContainerHtml === 'string') {
+        magicContainer.innerHTML = data.magicContainerHtml;
+        magicContainer.querySelectorAll('.magic-topic').forEach(topic => {
+          afterContentSanitize(topic);
+          if (topic.id) {
+            magicTopicMap.set(topic.id, topic);
+          }
+        });
+      }
     }
 
     const newPages = [];
@@ -7195,18 +7357,27 @@ ${document.querySelector('style').textContent}
         sectionInfo.temas.push({ id: topicId, titulo: title, page });
         newPages.push(page);
 
-        if (magicContainer && topicData?.magicId) {
-          const magicId = String(topicData.magicId);
-          let magicTopic = document.getElementById(magicId);
-          if (!magicTopic) {
-            magicTopic = document.createElement('div');
-            magicTopic.id = magicId;
-            magicTopic.className = 'magic-topic';
-            magicContainer.appendChild(magicTopic);
+        if (magicContainer) {
+          let magicId = '';
+          if (topicData?.magicId) {
+            magicId = String(topicData.magicId);
+          } else if (typeof topicData?.magicHtml === 'string') {
+            magicId = `magic-topic-${topicId}`;
           }
-          if (typeof topicData.magicHtml === 'string') {
-            magicTopic.innerHTML = topicData.magicHtml;
-            afterContentSanitize(magicTopic);
+
+          if (magicId) {
+            let magicTopic = magicTopicMap.get(magicId);
+            if (!magicTopic) {
+              magicTopic = document.createElement('div');
+              magicTopic.id = magicId;
+              magicTopic.className = 'magic-topic';
+              magicContainer.appendChild(magicTopic);
+              magicTopicMap.set(magicId, magicTopic);
+            }
+            if (typeof topicData.magicHtml === 'string') {
+              magicTopic.innerHTML = topicData.magicHtml;
+              afterContentSanitize(magicTopic);
+            }
           }
         }
       });


### PR DESCRIPTION
## Summary
- add a toolbar action to delete all sections/topics and reset the workspace state
- serialize and restore magic section content when exporting/importing data files
- make topic titles navigate on click and refresh image resizing UI with +/- controls

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e67c5b7a98832ca2e91fb3447e256c